### PR TITLE
Note Postgres' (current) RLS limitations for views

### DIFF
--- a/api.rst
+++ b/api.rst
@@ -98,6 +98,10 @@ The view will provide a new endpoint:
 
   GET /fresh_stories HTTP/1.1
 
+.. important::
+
+  Views bypass all row-level security features and are invoked as the role which created the view, much like stored procedures with the "SECURITY DEFINER" option.
+
 .. _fts:
 
 Full-Text Search

--- a/api.rst
+++ b/api.rst
@@ -100,7 +100,7 @@ The view will provide a new endpoint:
 
 .. important::
 
-  Views are invoked with the privileges of the view owner, much like stored procedures with the "SECURITY DEFINER" option. When created by a SUPERUSER role, all row-level security will be bypassed unless a different owner is specified.
+  Views are invoked with the privileges of the view owner, much like stored procedures with the "SECURITY DEFINER" option. When created by a SUPERUSER role, all row-level security will be bypassed unless a different, non-SUPERUSER owner is specified.
 
 .. _fts:
 

--- a/api.rst
+++ b/api.rst
@@ -100,7 +100,7 @@ The view will provide a new endpoint:
 
 .. important::
 
-  Views bypass all row-level security features and are invoked as the role which created the view, much like stored procedures with the "SECURITY DEFINER" option.
+  Views are invoked with the privileges of the view owner, much like stored procedures with the "SECURITY DEFINER" option. When created by a SUPERUSER role, all row-level security will be bypassed unless a different owner is specified.
 
 .. _fts:
 


### PR DESCRIPTION
This is a pretty major caveat for views which ought to be noted (see #172).

I did not  note the read-only workaround (create a stored procedure with the "SECURITY INVOKER" option).

Relevant chatter about this:
- https://stackoverflow.com/a/33863371
- https://www.postgresql.org/message-id/flat/CABFpK629xHR-jbgO0tiprMr9aZLiofMkQ3E7QxqHFRVFNcqnSQ%40mail.gmail.com