### PR TITLE
Fix miscellaneous Sphinx warnings

### DIFF
--- a/admin.rst
+++ b/admin.rst
@@ -272,7 +272,7 @@ As discussed in :ref:`singular_plural`, there are no special URL forms for singu
 
 .. code:: http
 
-  GET /people?id=eq.1
+  GET /people?id=eq.1 HTTP/1.1
   Accept: application/vnd.pgrst.object+json
 
 This allows compound primary keys and makes the intent for singular response independent of a URL convention.

--- a/index.rst
+++ b/index.rst
@@ -21,6 +21,7 @@
   :target: https://www.paypal.me/postgrest
 
 |
+
 PostgREST is a standalone web server that turns your PostgreSQL database directly into a RESTful API. The structural constraints and permissions in the database determine the API endpoints and operations.
 
 Sponsors

--- a/install.rst
+++ b/install.rst
@@ -304,7 +304,6 @@ The database connection string above is just an example. Adjust the role and pas
 
     host    all             all             10.0.0.10/32            trust
 
-
 Containerized PostgREST *and* db with docker-compose
 ----------------------------------------------------
 

--- a/install.rst
+++ b/install.rst
@@ -297,11 +297,13 @@ The database connection string above is just an example. Adjust the role and pas
   .. code-block:: bash
 
     listen_addresses = 'localhost,10.0.0.10'
+
   You might also need to add a new IPv4 local connection within pg_hba.conf. For instance:
-  
+
   .. code-block:: bash
-  
+
     host    all             all             10.0.0.10/32            trust
+
 
 Containerized PostgREST *and* db with docker-compose
 ----------------------------------------------------

--- a/tutorials/tut1.rst
+++ b/tutorials/tut1.rst
@@ -151,8 +151,10 @@ Go back to jwt.io and change the payload to
 
   {
     "role": "todo_user",
-    "exp": "<computed epoch value>"
+    "exp": 123456789
   }
+
+**NOTE**: Don't forget to change the dummy epoch value :code:`123456789` in the snippet above to the epoch value returned by the psql command.
 
 Copy the updated token as before, and save it as a new environment variable.
 

--- a/tutorials/tut1.rst
+++ b/tutorials/tut1.rst
@@ -151,7 +151,7 @@ Go back to jwt.io and change the payload to
 
   {
     "role": "todo_user",
-    "exp": <computed epoch value>
+    "exp": "<computed epoch value>"
   }
 
 Copy the updated token as before, and save it as a new environment variable.


### PR DESCRIPTION
Running `sphinx-build` (via the `make` targets at least) generates some minor warnings.

The PR fixes them, one per commit. Each warning is mentioned in the commit message.

Note: I couldn't find any contributing guideline, so indications are welcome.