### PR TITLE
Add server proxy uri env var for smoother swagger-ui  use with docker-compose

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -134,6 +134,7 @@ To avoid having to install the database at all, you can run both it and the serv
         PGRST_DB_URI: postgres://app_user:password@db:5432/app_db
         PGRST_DB_SCHEMA: public
         PGRST_DB_ANON_ROLE: app_user #In production this role should not be the same as the one used for the connection
+        PGRST_SERVER_PROXY_URI: "http://127.0.0.1:3000"
       depends_on:
         - db
     db:


### PR DESCRIPTION
When using swagger-ui with postgrest in docker compose, the host reported by the OpenAPI spec will default to `0.0.0.0` since this is the host on the container network. Since this is what swagger-ui uses for all but the first request, (to fetch the spec). This means that whenever `0.0.0.0` doesn't resolve to localhost on the host machine swagger-ui won't work. Setting `PGRST_SERVER_PROXY_URI` (server-proxy-uri) means a sensible default is set to make it more plug and play.