### PR TITLE
Credit tutorials and how-tos authors

### DIFF
--- a/how-tos/casting-type-to-custom-json.rst
+++ b/how-tos/casting-type-to-custom-json.rst
@@ -1,6 +1,8 @@
 Casting a type to a custom JSON object
 ======================================
 
+:author: `steve-chavez <https://github.com/steve-chavez>`_
+
 While using PostgREST you might have noticed that certain PostgreSQL types translate to JSON strings when you would
 have expected a JSON object or array. For example, let's see the case of `range types <https://www.postgresql.org/docs/11/rangetypes.html>`_.
 
@@ -82,7 +84,7 @@ You can use the same idea for creating custom CASTs for different types.
 
 .. note::
 
-   If you don't want to modify CASTs for built-in types, an option would be to `create a custom type <https://www.postgresql.org/docs/current/sql-createtype.html>`_ 
+   If you don't want to modify CASTs for built-in types, an option would be to `create a custom type <https://www.postgresql.org/docs/current/sql-createtype.html>`_
    for your own ``tsrange`` and add its own CAST.
 
    .. code-block:: postgres

--- a/how-tos/embedding-table-from-another-schema.rst
+++ b/how-tos/embedding-table-from-another-schema.rst
@@ -1,6 +1,8 @@
 Embedding a table from another schema
 =====================================
 
+:author: `steve-chavez <https://github.com/steve-chavez>`_
+
 Suppose you have a **people** table in the ``public`` schema and this schema is exposed through PostgREST's :ref:`db-schema`.
 
 .. code-block:: postgres

--- a/tutorials/tut0.rst
+++ b/tutorials/tut0.rst
@@ -3,6 +3,8 @@
 Tutorial 0 - Get it Running
 ===========================
 
+:author: `begriffs <https://github.com/begriffs>`_
+
 Welcome to PostgREST! In this pre-tutorial we're going to get things running so you can create your first simple API.
 
 PostgREST is a standalone web server which turns a PostgreSQL database into a RESTful API. It serves an API that is customized based on the structure of the underlying database.

--- a/tutorials/tut1.rst
+++ b/tutorials/tut1.rst
@@ -3,6 +3,8 @@
 Tutorial 1 - The Golden Key
 ===========================
 
+:author: `begriffs <https://github.com/begriffs>`_
+
 In :ref:`tut0` we created a read-only API with a single endpoint to list todos. There are many directions we can go to make this API more interesting, but one good place to start would be allowing some users to change data in addition to reading it.
 
 Step 1. Add a Trusted User


### PR DESCRIPTION
Doing `tutorials` and `how-tos` take considerable time and effort. I want to credit authors as a way to encourage more contributions.

The link to authors profiles can be any of their choosing(github, website, etc).

Since how-tos can be so diverse, I'm thinking we could even allow blog posts/articles from external websites and link them to our [how-tos section](https://postgrest.org/en/preview/index.html#how-to-guides).

Author preview samples:

- https://postgrest.org/en/preview/tutorials/tut0.html
- https://postgrest.org/en/preview/how-tos/casting-type-to-custom-json.html

Ideally this would look better but for now I just left it with readthedocs default css.

(cc @begriffs)