### PR TITLE
Scarf install instructions

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -25,6 +25,15 @@ The release page has pre-compiled binaries for Mac OS X, Windows, and several Li
   It usually lives in :code:`C:\Program Files\PostgreSQL\<version>\bin`. See this `article <https://www.howtogeek.com/118594/how-to-edit-your-system-path-for-easy-command-line-access/>`_ about how to modify the system path.
 
 
+With Scarf
+==========
+
+If you're installing on Mac or Linux, please consider supporting PostgREST by installing with the `Scarf package manager <https://scarf.sh>`_.
+
+.. code-block:: bash
+
+   $ scarf install postgrest
+
 PostgreSQL dependency
 =====================
 

--- a/tutorials/tut0.rst
+++ b/tutorials/tut0.rst
@@ -56,6 +56,12 @@ The result will be a file named simply :code:`postgrest` (or :code:`postgrest.ex
 
   ./postgrest
 
+If you're installing on Mac or Linux, please consider supporting PostgREST by installing with the `Scarf package manager <https://scarf.sh>`_.
+
+.. code-block:: bash
+
+   $ scarf install postgrest
+
 If everything is working correctly it will print out its version and information about configuration. You can continue to run this binary from where you downloaded it, or copy it to a system directory like :code:`/usr/local/bin` on Linux so that you will be able to run it from any directory.
 
 .. note::


### PR DESCRIPTION
Hello! This change adds install instructions for postgrest with the [Scarf](https://scarf.sh) package manager (disclaimer: I'm the author of Scarf).

I saw that postgrest is using Github Sponsors. Scarf could be an additional way to support this project, especially from those using it in a commercial setting. It will collect and provide you with usage statistics as well as offer the ability to collect payments to opt out, so anyone who installs postgrest in this way will be supporting the project in one form or another.

I'd be happy to transfer package ownership and/or co-maintain it, so no extra work required on your part. Let me know what you think!