### PR TITLE
Add schema basic.auth for the creation of user jwt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _build
 Pipfile.lock
+.idea

--- a/auth.rst
+++ b/auth.rst
@@ -363,7 +363,7 @@ Next we'll use the pgcrypto extension and a trigger to keep passwords safe in th
   basic_auth.encrypt_pass() returns trigger as $$
   begin
     if tg_op = 'INSERT' or new.pass <> old.pass then
-      new.pass = crypt(new.pass, gen_salt('bf'));
+      new.pass = basic_auth.crypt(new.pass, basic_auth.gen_salt('bf'));
     end if;
     return new;
   end


### PR DESCRIPTION
Hello, following the following error when creating jwt users: 

SQL Error [42883]: ERROR: function gen_salt(unknown) does not exist
  Indice : No function matches the given name and argument types. You might need to add explicit type casts.
I adapted and validated.