### PR TITLE
Remove keepalive nginx recommendation

### DIFF
--- a/admin.rst
+++ b/admin.rst
@@ -12,7 +12,6 @@ The first step is to create an Nginx configuration file that proxies requests to
     # upstream configuration
     upstream postgrest {
       server localhost:3000;
-      keepalive 64;
     }
     # ...
     server {


### PR DESCRIPTION
Related to https://github.com/PostgREST/postgrest/issues/1399#issuecomment-554906927.

I'm not sure exactly why this happens since I haven't reproduced the issue. However, our initial nginx recommendation should be simple and adding optimizations could be left to a more advanced section. 