### PR TITLE
Tutorial: Providing images for <img>

### DIFF
--- a/how-tos/providing-images-for-img.rst
+++ b/how-tos/providing-images-for-img.rst
@@ -32,7 +32,7 @@ First, we need a public table for storing the files.
    );
 
 Let's assume this table contains an image of two cute kittens with id 42.
-We can retrieve this image in binary format from our PostgREST API by requesting :code:`/files?select=blog&id=eq.42` with the :code:`Accept: application/octet-stream` header.
+We can retrieve this image in binary format from our PostgREST API by requesting :code:`/files?select=blob&id=eq.42` with the :code:`Accept: application/octet-stream` header.
 Unfortunately, putting the URL into the :code:`src` of an :code:`<img>` tag will not work.
 That's because browsers do not send the required header.
 
@@ -118,8 +118,9 @@ For production, you probably want to configure additional caches, e.g. on the re
      end
    $$ language plpgsql;
 
-With this, we can obtain the cat image from `/rpc/file?id=42`.
+With this, we can obtain the cat image from :code:`/rpc/file?id=42`.
 Consequently, we have to replace our previous rewrite rule in the Nginx recipe with the following.
 
 .. code-block:: nginx
+
    rewrite /files/([^/]+).*  /rpc/file?id=$1  break;

--- a/how-tos/providing-images-for-img.rst
+++ b/how-tos/providing-images-for-img.rst
@@ -25,6 +25,7 @@ We will show how to achieve this using Nginx.
 First, we need a public table for storing the files.
 
 .. code-block:: postgres
+
    create table public.files(
      id   int primary key
    , blob bytea

--- a/how-tos/providing-images-for-img.rst
+++ b/how-tos/providing-images-for-img.rst
@@ -31,15 +31,15 @@ First, we need a public table for storing the files.
    );
 
 Let's assume this table contains an image of two cute kittens with id 42.
-We can retrieve this image in binary format from our PostgREST API by requesting ::code::`/files?select=blog&id=eq.42` with the :code:`Accept: application/octet-stream` header.
-Unfortunately, putting the URL into the ::code::`src` of an ::code::`<img>` tag will not work.
+We can retrieve this image in binary format from our PostgREST API by requesting :code:`/files?select=blog&id=eq.42` with the :code:`Accept: application/octet-stream` header.
+Unfortunately, putting the URL into the :code:`src` of an :code:`<img>` tag will not work.
 That's because browsers do not send the required header.
 
 Luckily, we can configure our Nginx reverse proxy to fix this problem for us.
 The following recipe assumes that PostgREST is running on port 3000.
 It configures Nginx as ordinary HTTP server on port 80.
-Requests to ::code::`/api/*` are forwarded to our PostgREST instance.
-Requests to ::code::`/files/<id>*` are forwarded to our endpoint with the ::code::`Accept` header set to ::code::`application/octet-stream`.
+Requests to :code:`/api/*` are forwarded to our PostgREST instance.
+Requests to :code:`/files/<id>*` are forwarded to our endpoint with the :code:`Accept` header set to :code:`application/octet-stream`.
 
 .. code-block:: nginx
    server {
@@ -74,23 +74,23 @@ Requests to ::code::`/files/<id>*` are forwarded to our endpoint with the ::code
        proxy_pass http://localhost:3000/;
      }
 
-As you can see, we only explain the ::code::`files` location.
+As you can see, we only explain the :code:`files` location.
 The reasoning for the rest of the recipe can be found elsewhere_.
 
 .. _elsewhere: ../admin.html#
 
-With this setup, we can request the cat image at ::code::`localhost/files/42/cats.jpeg` without setting any headers.
-In fact, you can replace ::code::`cats.jpeg` with any other filename or simply omit it.
-Putting the URL into the ::code::`src` of an ::code::`<img>` tag should now work as expected.
+With this setup, we can request the cat image at :code:`localhost/files/42/cats.jpeg` without setting any headers.
+In fact, you can replace :code:`cats.jpeg` with any other filename or simply omit it.
+Putting the URL into the :code:`src` of an :code:`<img>` tag should now work as expected.
 
 Improved Version
 ----------------
 
 The basic solution has some shortcomings:
 
-1.  The response ::code::`Content-Type` header is set to ::code::`application/octet-stream`.
+1.  The response :code:`Content-Type` header is set to :code:`application/octet-stream`.
     This might confuse clients and users.
-2.  Download requests (e.g. Right Click -> Save Image As) to ::code::`files/42` will propose ::code::`42` as filename.
+2.  Download requests (e.g. Right Click -> Save Image As) to :code:`files/42` will propose :code:`42` as filename.
     This might confuse users.
 3.  Requests to the binary endpoint are not cached.
     This will cause unnecessary load on the database.

--- a/how-tos/providing-images-for-img.rst
+++ b/how-tos/providing-images-for-img.rst
@@ -26,7 +26,7 @@ First, we need a public table for storing the files.
 
 .. code-block:: postgres
 
-   create table public.files(
+   create table files(
      id   int primary key
    , blob bytea
    );
@@ -77,9 +77,7 @@ Requests to :code:`/files/<id>*` are forwarded to our endpoint with the :code:`A
      }
 
 As you can see, we only explain the :code:`files` location.
-The reasoning for the rest of the recipe can be found elsewhere_.
-
-.. _elsewhere: ../admin.html#
+The reasoning for the rest of the recipe can be found `elsewhere <../admin.html>`_.
 
 With this setup, we can request the cat image at :code:`localhost/files/42/cats.jpeg` without setting any headers.
 In fact, you can replace :code:`cats.jpeg` with any other filename or simply omit it.
@@ -101,6 +99,7 @@ The following improved version addresses these problems.
 First, we store the media types and names of our files in the database.
 
 .. code-block:: postgres
+
    create table public.files(
      id   int primary key
    , type text
@@ -113,6 +112,7 @@ We use this opportunity to configure some basic, client-side caching.
 For production, you probably want to configure additional caches, e.g. on the reverse proxy.
 
 .. code-block:: postgres
+
    set search_path=public
 
    create function file(id int) returns bytea as

--- a/how-tos/providing-images-for-img.rst
+++ b/how-tos/providing-images-for-img.rst
@@ -3,7 +3,7 @@ Providing images for <img>
 
 :author: `pkel <https://github.com/pkel>`_
 
-In this tutorial, you will learn how to create an endpoint for providing images to HTML :code:<img> tags without client side javascript.
+In this how-to, you will learn how to create an endpoint for providing images to HTML :code:`<img>` tags without client side javascript.
 The resulting HTML might look like this:
 
 .. code-block:: html

--- a/how-tos/providing-images-for-img.rst
+++ b/how-tos/providing-images-for-img.rst
@@ -43,6 +43,7 @@ Requests to :code:`/api/*` are forwarded to our PostgREST instance.
 Requests to :code:`/files/<id>*` are forwarded to our endpoint with the :code:`Accept` header set to :code:`application/octet-stream`.
 
 .. code-block:: nginx
+
    server {
      listen 80 default_server;
      listen [::]:80 default_server;

--- a/how-tos/providing-images-for-img.rst
+++ b/how-tos/providing-images-for-img.rst
@@ -1,0 +1,86 @@
+Providing images for <img>
+==========================
+
+:author: `pkel <https://github.com/pkel>`_
+
+In this tutorial, you will learn how to create an endpoint for providing images to HTMl :code:<img> tags without client side javascript:
+
+.. code-block:: html
+
+   <img src="http://your.host/api/images?select=blob&id=eq.42" alt="Cute Kittens"/>
+
+A browser encountering this this tag will send a request to your API.
+It will set the :code:`Accept` header to something like :code:`image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5`, indicating that it prefers PNGs and SVGs over other media types.
+We observe, that the wildcard media type :code:`image/*` is present independent of the browser.
+
+PostgREST can return binary data from :code:`bytea` columns.
+Per default, this happens only if the clients sends the :code:`Accept: application/octet-stream` header.
+As you see, the browser's image request does not line up with the required media type.
+Luckily, since version 6, we can configure additional binary media types.
+After adding
+
+.. code-block:: bash
+
+   raw-media-types='image/*'
+
+to the PostgREST configuration, we only have to create an appropriate endpoint:
+
+.. code-block:: postgres
+
+   create table public.images(
+     id   int primary key
+   , blob bytea
+   );
+
+In principle, you are ready to go with this minimum configuration.
+
+Response headers
+----------------
+
+The above configuration has some problems:
+
+- The served images will not be cached.
+  This imposes stress on your database.
+- The return content type is the first one given in the :code:`Accept` header.
+  In the above example it would be `image/png`, even when you return a JPG file.
+  This will confuse users when using the *Save image as* feature of their browser.
+- The browser will derive a filename from the request URL.
+  This will likely go wrong and confuse users.
+
+We can address these problems by setting custom response headers.
+This is only possible from within stored procedures, so we have to adapt our schema a little bit.
+
+.. code-block:: postgres
+
+   set search_path=public
+
+   create table images(
+     id   int primary key
+   , name text
+   , type text
+   , blob bytea
+   );
+
+   create or replace function image(id int) returns bytea as
+   $$
+     declare headers text;
+     begin
+       select format('[{"Content-Type": "%s"}, {"Content-Disposition": "attachment, filename=\"%s\""}, {"Cache-Control": "max-age=259200"}]', i.type, i.name)
+         from images as i where i.id = image.id into headers;
+       perform set_config('response.headers', headers, true);
+       return(select blob from images as i where i.id = image.id);
+     end
+   $$ language plpgsql;
+
+We also adapt the HTML snippet:
+
+.. code-block:: html
+
+   <img src="http://your.host/api/rpc/image?id=42" alt="Cute Kittens"/>
+
+To Do
+-----
+
+- Return 404 when id is not present in table.
+  How can we do it?
+- If we could trigger raw output via a config parameter from within the procedure, we could provide a generic file endpoint.

--- a/index.rst
+++ b/index.rst
@@ -126,6 +126,7 @@ These are recipes that'll help you address specific use-cases.
 
 - :doc:`how-tos/casting-type-to-custom-json`
 - :doc:`how-tos/embedding-table-from-another-schema`
+- :doc:`how-tos/providing-images-for-img`
 
 Topic guides
 ------------


### PR DESCRIPTION
I tried to setup an endpoint for providing binary data for <img> tags. This is what I found out.

I need some help with the following point.
- Return 404 when the requested id is not present in table.

If we could trigger raw output via a config parameter from within the procedure, we could provide a generic file endpoint. Setting `raw-media-types= */*` is probably not a good idea. Is this worth a
feature request?

Addresses #233.