### PR TITLE
Fix the 'Roles for Each Web User' example

### DIFF
--- a/auth.rst
+++ b/auth.rst
@@ -60,6 +60,8 @@ You can use row-level security to flexibly restrict visibility and access for th
     message_subject VARCHAR(64) NOT NULL,
     message_body    TEXT
   );
+  
+  ALTER TABLE chat ENABLE ROW LEVEL SECURITY;
 
 We want to enforce a policy that ensures a user can see only those messages sent by him or intended for him. Also we want to prevent a user from forging the message_from column with another person's name.
 
@@ -95,7 +97,7 @@ SQL code can access claims through GUC variables set by PostgREST per request. F
 
   current_setting('request.jwt.claim.email', true)
 
-This allows JWT generation services to include extra information and your database code to react to it. For instance the RLS example could be modified to use this current_setting rather than current_user.  The second 'true' argument tells current_setting to return NULL if the setting is missing from the current configuration.
+This allows JWT generation services to include extra information and your database code to react to it. For instance the RLS example could be modified to use this current_setting rather than current_user. The second 'true' argument tells current_setting to return NULL if the setting is missing from the current configuration.
 
 Hybrid User-Group Roles
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I struggled for a while to make it work, but in the end found that https://www.postgresql.org/docs/9.5/sql-createpolicy.html says you have to run `ALTER TABLE ... ENABLE ROW LEVEL SECURITY;` and that appears to have fixed the issue.

Also I'm not sure the documentation about `current_setting` would be good practice. If you do not pass the `true` argument to return NULL if the setting is missing the error will be much more obvious (and this is also what is done in the [linked tutorial](https://www.2ndquadrant.com/en/blog/application-users-vs-row-level-security/)).

In my opinion `current_setting('request.jwt.claim.email')` would be better, but let me know what you think because I'm not exactly an expert.