### PR TITLE
Fix link to DigitalOcean PostgREST Contact List video

### DIFF
--- a/ecosystem.rst
+++ b/ecosystem.rst
@@ -3,7 +3,7 @@
 Community Tutorials
 -------------------
 
-* `Building a Contacts List with PostgREST and Vue.js <https://www.youtube.com/playlist?list=PLseEp7p6EwibFjhfO6LhMx5_SFkVxt_gf>`_ -
+* `Building a Contacts List with PostgREST and Vue.js <https://www.youtube.com/watch?v=iHtsALtD5-U>`_ -
   In this video series, DigitalOcean shows how to build and deploy an Nginx + PostgREST(using a managed PostgreSQL database) + Vue.js webapp in an Ubuntu server droplet.
 
 * `PostgREST + Auth0: Create REST API in mintutes and add social login using Auth0 <https://samkhawase.com/blog/postgrest_introduction/>`_ - A step-by-step tutorial to show how to Dockerize and integrate Auth0 to PostgREST service.


### PR DESCRIPTION
Old playlist is gone - linked to first video in series instead