### PR TITLE
add redux-postgrest to client-side libraries

### DIFF
--- a/ecosystem.rst
+++ b/ecosystem.rst
@@ -89,6 +89,8 @@ Client-Side Libraries
 * `PierreRochard/postgrest-angular <https://github.com/PierreRochard/postgrest-angular>`_ - TypeScript, generate UI from API description
 * `thejettdurham/postgrest-sharp-client <https://github.com/thejettdurham/postgrest-sharp-client>`_ (needs maintainer) - C#, RestSharp
 * `team142/ng-postgrest <https://github.com/team142/ng-postgrest>`_ - Angular app for browsing, editing data exposed over Postgrest.
+* `andytango/redux-postgrest <https://github.com/andytango/redux-postgrest>`_ - TypeScript/JS, client integrated with (React) Redux.
+
 
 .. _eco_commercial:
 


### PR DESCRIPTION
As per https://github.com/andytango/redux-postgrest/issues/7

<!--
When adding a new doc section or page, please add an entry to releases/upcoming.rst.
-->
