### PR TITLE
Fix links to pg-safeupdate 

### DIFF
--- a/admin.rst
+++ b/admin.rst
@@ -51,7 +51,7 @@ However it's very easy to delete the **entire table** by omitting the query para
 
   DELETE /logs HTTP/1.1
 
-This can happen accidentally such as by switching a request from a GET to a DELETE. To protect against accidental operations use the `pg-safeupdate <https://bitbucket.org/eradman/pg-safeupdate/>`_ PostgreSQL extension. It raises an error if UPDATE or DELETE are executed without specifying conditions. To install it you can use the `PGXN <http://pgxn.org/>`_ network:
+This can happen accidentally such as by switching a request from a GET to a DELETE. To protect against accidental operations use the `pg-safeupdate <https://github.com/eradman/pg-safeupdate>`_ PostgreSQL extension. It raises an error if UPDATE or DELETE are executed without specifying conditions. To install it you can use the `PGXN <http://pgxn.org/>`_ network:
 
 .. code-block:: bash
 

--- a/ecosystem.rst
+++ b/ecosystem.rst
@@ -61,7 +61,7 @@ These are PostgreSQL bridges that propagate LISTEN/NOTIFY to external queues for
 Extensions
 ----------
 
-* `pg-safeupdate <https://bitbucket.org/eradman/pg-safeupdate/>`_ - Prevent full-table updates or deletes
+* `pg-safeupdate <https://github.com/eradman/pg-safeupdate>`_ - Prevent full-table updates or deletes
 * `srid/spas <https://github.com/srid/spas>`_ - allow file uploads and basic auth
 * `svmnotn/postgrest-auth <https://github.com/svmnotn/postgrest-auth>`_ - OAuth2-inspired external auth server
 * `wildsurfer/postgrest-oauth-server <https://github.com/wildsurfer/postgrest-oauth-server>`_ - OAuth2 server


### PR DESCRIPTION
Change broken Bitbucket links for pg-safeupdate to GitHub.

For issue #336