### PR TITLE
Add Windows installation using Scoop to install page

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -30,6 +30,12 @@ If you use **Nix**, then you can install PostgREST from nixpkgs.
 
   nix-env -i haskellPackages.postgrest
 
+If you use Windows, you can install PostgREST using `Scoop command-line installer <https://scoop.sh>`_.
+
+.. code:: bash
+
+  scoop install postgrest
+
 When a pre-built binary does not exist for your system you can :ref:`build the project from source <build_source>`.
 
 Running


### PR DESCRIPTION
This PR if a follow up to 
- [PostgRest#1445](https://github.com/PostgREST/postgrest/issues/1445): Chocolatey or scoop package for PostgREST
- [ScoopMain#1250](https://github.com/ScoopInstaller/Main/pull/1250): postgrest: Add version 7.0.1 