### PR TITLE
make docs full-width, resolves #351

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1,3 +1,15 @@
+.wy-nav-content {
+  max-width: initial;
+}
+
+#postgrest-documentation {
+  max-width: 800px;
+}
+
+#postgrest-documentation > h1 {
+  display: none;
+}
+
 div.wy-menu.rst-pro {
   display: none !important;
 }
@@ -10,11 +22,11 @@ div.line-block {
   margin-bottom: 0px !important;
 }
 
-#sponsors{
+#sponsors {
   text-align: center;
 }
 
-#sponsors h1{
+#sponsors h2 {
   text-align: left;
 }
 

--- a/index.rst
+++ b/index.rst
@@ -1,5 +1,8 @@
 .. title:: PostgREST Documentation
 
+PostgREST Documentation
+=======================
+
 .. figure:: _static/logo.png
 
 .. image:: https://img.shields.io/github/stars/postgrest/postgrest.svg?style=social


### PR DESCRIPTION
While this "works", I'm not 100% convinced, yet. We tend to not have as much text and those single sentences stretched out across the whole screen are not really better to read. Do we need to do more styling here?

I tried just copying in all the linux-docs css overrides (as this style as mentioned in #351), but I'm not sure of that either.

What do you think @steve-chavez?