### PR TITLE
For discussion: Remove obsolete stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,3 @@ Translations are maintained in separate repositories forked from this one. Once 
 to https://readthedocs.org and we'll link to it in the official documentation site https://postgrest.org.
 
 See more details in the chinese translation [PR](https://github.com/PostgREST/postgrest-docs/issues/66#issuecomment-297431688).
-
-### Available translations
-
-- Chinese - https://github.com/Lellansin/postgrest-docs (latest version `v0.4.2.0`)

--- a/README.md
+++ b/README.md
@@ -18,10 +18,3 @@ Once in the nix-shell you have the following commands available:
 
 This documentation is structured according to tutorials-howtos-topics-references. For more details on the rationale of this structure, 
 see https://www.divio.com/blog/documentation.
-
-## Translations
-
-Translations are maintained in separate repositories forked from this one. Once you finish translating in your fork you can upload the project
-to https://readthedocs.org and we'll link to it in the official documentation site https://postgrest.org.
-
-See more details in the chinese translation [PR](https://github.com/PostgREST/postgrest-docs/issues/66#issuecomment-297431688).


### PR DESCRIPTION
Removing a couple of things where I feel we don't need them anymore. Split up in 3 commits, because some of them might be more controversial then others ;)

1. Makefile and Pipfile: The Makefile does not seem to be used at all. If anything from that is needed, we should add nix-tools instead. The Pipfile would only make sense when not using nix, but I don't it's worth to maintain it. I tried it once, but using it failed because I have python3.8 and not 3.6 on the system. I then gave up and used nix - worked instantly. Regarding the Makefile I also checked the build-log for readthedocs, it seems to run the needed commands itself without the makefile. Should be safe to remove.

2. The chinese translation is heavily outdated - I don't think there is any value in pointing to it anymore. There's another issue with it: If you click on the zh translation on readthedocs, it will not show the version this is for anymore, but just "latest". That is very confusing at best and not helpful. It's very unlikely that this the translation will be updated anytime as it's much work. So I suggest to remove it here and from readthedocs (I don't think I can do it there, missing privileges - you would need to do that, @steve-chavez, if you agree).

3. That one might be a bit more controversial: I suggest to remove the whole section about translations from the Readme. It seems quite unlikely that there will be any other translations and we sure don't want to maintain those - we already have trouble keeping up with the english docs after all :). If anyone shows up and is heavily interested in maintaining a translation properly, they will sure get in touch, even without this section. Short: Let's focus more on getting the english translations up2date instead of carrying old stuff around.

Thoughts?