### PR TITLE
Fix outdated environment variable for docker compose

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -172,13 +172,11 @@ To avoid having to install the database at all, you can run both it and the serv
       image: postgrest/postgrest
       ports:
         - "3000:3000"
-      links:
-        - db:db
       environment:
         PGRST_DB_URI: postgres://app_user:password@db:5432/app_db
         PGRST_DB_SCHEMA: public
         PGRST_DB_ANON_ROLE: app_user #In production this role should not be the same as the one used for the connection
-        PGRST_SERVER_PROXY_URI: "http://127.0.0.1:3000"
+        PGRST_OPENAPI_SERVER_PROXY_URI: "http://127.0.0.1:3000"
       depends_on:
         - db
     db:


### PR DESCRIPTION
Also removed a deprecated `links` setting from the docker-compose, since that's not needed any more

Resolves #379 