### PR TITLE
Change port in configuration of db-uri to default PostgreSQL port (5432).

### DIFF
--- a/tutorials/tut0.rst
+++ b/tutorials/tut0.rst
@@ -161,7 +161,7 @@ PostgREST uses a configuration file to tell it how to connect to the database. C
 
 .. code-block:: ini
 
-  db-uri = "postgres://authenticator:mysecretpassword@localhost:5433/postgres"
+  db-uri = "postgres://authenticator:mysecretpassword@localhost:5432/postgres"
   db-schema = "api"
   db-anon-role = "web_anon"
 


### PR DESCRIPTION
<!--
Please change port in configuration of db-uri to default PostgreSQL port (5432). I faced with a problem with connection to PostgreSQL with port 5433 pointed in tutoiral0.
-->
