### PR TITLE
Update api.rst

### DIFF
--- a/api.rst
+++ b/api.rst
@@ -1484,9 +1484,9 @@ PostgREST reads the ``response.headers`` SQL variable to add extra headers to th
 
   -- tell client to cache response for two days
 
-  SET LOCAL "response.headers" =
-    '[{"Cache-Control": "public"}, {"Cache-Control": "max-age=259200"}]';
-
+  SELECT set_config('response.headers',
+    '[{"Cache-Control": "public"}, {"Cache-Control": "max-age=259200"}]', true);
+  
 Notice that the variable should be set to an *array* of single-key objects rather than a single multiple-key object. This is because headers such as ``Cache-Control`` or ``Set-Cookie`` need to be repeated when setting multiple values and an object would not allow the repeated key.
 
 .. note::


### PR DESCRIPTION
Changed SET LOCAL to SELECT set_config( ... ) so that the value of the header can be dynamically calculated. Supported in versions 9.6 and above.

<!--
When adding a new doc section or page, please add an entry to releases/upcoming.rst.
-->
