### PR TITLE
Add db-tx-end config option

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -39,6 +39,7 @@ db-anon-role             String                    Y
 db-pool                  Int     10
 db-pool-timeout          Int     10
 db-extra-search-path     String  public
+db-tx-end                String  commit
 server-host              String  !4
 server-port              Int     3000
 server-unix-socket       String
@@ -132,6 +133,27 @@ db-extra-search-path
   This parameter was meant to make it easier to use **PostgreSQL extensions** (like PostGIS) that are outside of the :ref:`db-schema`.
 
   Multiple schemas can be added in a comma-separated string, e.g. ``public, extensions``.
+
+.. _db-tx-end:
+
+db-tx-end
+---------
+
+  Specifies how to terminate the database transactions.
+
+  .. code:: bash
+
+    # The transaction is always committed
+    db-tx-end = "commit"
+
+    # The transaction is committed unless a Prefer: tx=rollback header is used
+    db-tx-end = "commit-allow-override"
+
+    # The transaction is always rolled back
+    db-tx-end = "rollback"
+
+    # The transaction is rolled back unless a Prefer: tx=commit header is used
+    db-tx-end = "rollback"
 
 .. _server-host:
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -146,13 +146,13 @@ db-tx-end
     # The transaction is always committed
     db-tx-end = "commit"
 
-    # The transaction is committed unless a Prefer: tx=rollback header is used
+    # The transaction is committed unless a "Prefer: tx=rollback" header is sent
     db-tx-end = "commit-allow-override"
 
     # The transaction is always rolled back
     db-tx-end = "rollback"
 
-    # The transaction is rolled back unless a Prefer: tx=commit header is used
+    # The transaction is rolled back unless a "Prefer: tx=commit" header is sent
     db-tx-end = "rollback"
 
 .. _server-host:

--- a/postgrest.dict
+++ b/postgrest.dict
@@ -142,6 +142,7 @@ todo
 todos
 Tsingson
 tsquery
+tx
 TypeScript
 UI
 ui

--- a/releases/upcoming.rst
+++ b/releases/upcoming.rst
@@ -22,6 +22,9 @@ Added
 * Config option for logging level. See :ref:`log-level`.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
 
+* Config option for specifying how to terminate the transactions (allowing rollbacks). See :ref:`db-tx-end`.
+  |br| -- `@wolfgangwalther <https://github.com/wolfgangwalther>`_
+
 * Documentation improvements
 
   + Added the :ref:`OPTIONS requests <options_requests>` section.

--- a/releases/upcoming.rst
+++ b/releases/upcoming.rst
@@ -22,7 +22,7 @@ Added
 * Config option for logging level. See :ref:`log-level`.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
 
-* Config option for specifying how to terminate the transactions (allowing rollbacks). See :ref:`db-tx-end`.
+* Config option for specifying how to terminate the transactions (allowing rollbacks, useful for testing). See :ref:`db-tx-end`.
   |br| -- `@wolfgangwalther <https://github.com/wolfgangwalther>`_
 
 * Documentation improvements


### PR DESCRIPTION
Added documentation on `db-tx-end` config option according to https://github.com/PostgREST/postgrest/pull/1659 and https://github.com/PostgREST/postgrest/pull/1668.