### PR TITLE
Add db-prepared-statements config option

### DIFF
--- a/admin.rst
+++ b/admin.rst
@@ -129,19 +129,7 @@ In order to increase performance, PostgREST uses prepared statements by default.
 
 .. note::
 
-  PostgREST detects that transaction pooling is probably being used while prepared statements are enabled when getting an error like this one:
-
-  .. code:: json
-
-    {"hint":null,"details":null,"code":"42P05","message":"prepared statement \"0\" already exists"}
-
-  And for session pooling, in any case:
-
-  .. code:: json
-
-    {"hint":null,"details":null,"code":"08P01","message":"transaction blocks not allowed in statement pooling mode"}
-
-  Both will stop PostgREST from running when detected.
+  If prepared statements are enabled, PostgREST will quit after detecting that transaction or statement pooling is being used.
 
 You should also set the ``db-channel-enabled`` config option to ``false``, due to the ``LISTEN`` command not being compatible with transaction pooling, although it should not give any errors if it's left enabled by default.
 

--- a/admin.rst
+++ b/admin.rst
@@ -125,7 +125,7 @@ Nginx rate limiting is general and indiscriminate. To rate limit each authentica
 Using Connection Poolers
 ------------------------
 
-In order to increase performance, PostgREST uses prepared statements by default. However, this setting is incompatible with connection poolers such as PgBouncer working in transaction mode. In this case, you need to set the :ref:`db-prepared-statements` config option to ``false``; this way, the statements will be parametrized but they will not be prepared (expect to see a decrease in performance of around 23% according to our benchmarks). On the other hand, session pooling is fully compatible with PostgREST, while statement pooling is not compatible at all.
+In order to increase performance, PostgREST uses prepared statements by default. However, this setting is incompatible with connection poolers such as PgBouncer working in transaction mode. In this case, you need to set the :ref:`db-prepared-statements` config option to ``false``; this way, the statements will be parameterized but they will not be prepared (expect to see a decrease in performance of around 23% according to our benchmarks). On the other hand, session pooling is fully compatible with PostgREST, while statement pooling is not compatible at all.
 
 .. note::
 

--- a/admin.rst
+++ b/admin.rst
@@ -120,6 +120,31 @@ The burst argument tells Nginx to start dropping requests if more than five queu
 
 Nginx rate limiting is general and indiscriminate. To rate limit each authenticated request individually you will need to add logic in a :ref:`Custom Validation <custom_validation>` function.
 
+.. _connection_poolers:
+
+Using Connection Poolers
+------------------------
+
+In order to increase performance, PostgREST uses prepared statements by default. However, this setting is incompatible with connection poolers such as PgBouncer working in transaction mode. In this case, you need to set the :ref:`db-prepared-statements` config option to ``false``; this way, the statements will be parametrized but they will not be prepared (expect to see a decrease in performance of around 23% according to our benchmarks). On the other hand, session pooling is fully compatible with PostgREST, while statement pooling is not compatible at all.
+
+.. note::
+
+  PostgREST detects that transaction pooling is probably being used while prepared statements are enabled when getting an error like this one:
+
+  .. code:: json
+
+    {"hint":null,"details":null,"code":"42P05","message":"prepared statement \"0\" already exists"}
+
+  For session pooling, in any case:
+
+  .. code:: json
+
+    {"hint":null,"details":null,"code":"08P01","message":"transaction blocks not allowed in statement pooling mode"}
+
+  Both will stop PostgREST from running when detected.
+
+You should also set the ``db-channel-enabled`` config option to ``false``, due to the ``LISTEN`` channel not being compatible with transaction pooling, although it should not give any errors if it's left enabled by default.
+
 Debugging
 =========
 

--- a/admin.rst
+++ b/admin.rst
@@ -125,7 +125,7 @@ Nginx rate limiting is general and indiscriminate. To rate limit each authentica
 Using Connection Poolers
 ------------------------
 
-In order to increase performance, PostgREST uses prepared statements by default. However, this setting is incompatible with connection poolers such as PgBouncer working in transaction mode. In this case, you need to set the :ref:`db-prepared-statements` config option to ``false``; this way, the statements will be parameterized but they will not be prepared (expect to see a decrease in performance of around 23% according to our benchmarks). On the other hand, session pooling is fully compatible with PostgREST, while statement pooling is not compatible at all.
+In order to increase performance, PostgREST uses prepared statements by default. However, this setting is incompatible with connection poolers such as PgBouncer working in transaction pooling mode. In this case, you need to set the :ref:`db-prepared-statements` config option to ``false``. On the other hand, session pooling is fully compatible with PostgREST, while statement pooling is not compatible at all.
 
 .. note::
 
@@ -135,7 +135,7 @@ In order to increase performance, PostgREST uses prepared statements by default.
 
     {"hint":null,"details":null,"code":"42P05","message":"prepared statement \"0\" already exists"}
 
-  For session pooling, in any case:
+  And for session pooling, in any case:
 
   .. code:: json
 
@@ -143,7 +143,7 @@ In order to increase performance, PostgREST uses prepared statements by default.
 
   Both will stop PostgREST from running when detected.
 
-You should also set the ``db-channel-enabled`` config option to ``false``, due to the ``LISTEN`` channel not being compatible with transaction pooling, although it should not give any errors if it's left enabled by default.
+You should also set the ``db-channel-enabled`` config option to ``false``, due to the ``LISTEN`` command not being compatible with transaction pooling, although it should not give any errors if it's left enabled by default.
 
 Debugging
 =========

--- a/configuration.rst
+++ b/configuration.rst
@@ -140,7 +140,7 @@ db-extra-search-path
 db-prepared-statements
 ----------------------
 
-  Enables or disables prepared statements. You should set it to ``false`` only when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction mode. See :ref:`connection_poolers`.
+  Enables or disables prepared statements. You should set it to ``false`` only when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction pooling mode; this way, the statements will be parameterized but they will not be prepared (expect to see a decrease in performance of around 23% according to our benchmarks). See :ref:`this section <connection_poolers>` for more information on using connection poolers.
 
 .. _db-tx-end:
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -139,21 +139,7 @@ db-extra-search-path
 db-prepared-statements
 ----------------------
 
-  Enables or disables prepared statements. You should set it to ``false`` when using PostgresSQL behind a connection pooler, like PgBouncer, working in transaction mode; this way, the statements will be parametrized but they will not be prepared.
-
-  Disabling this is not necessary when no transaction pooler is used or if one is working in session pooling mode. On the other hand, statement pooling mode is not compatible with PostgREST.
-
-  These are some errors you could get when using a connection pooler while this setting is enabled:
-
-  .. code-block::
-
-    # Connection pooler in transaction mode
-    {"hint":null,"details":null,"code":"42P05","message":"prepared statement \"0\" already exists"}
-    Hint: If you are using connection poolers in transaction mode, try setting db-prepared-statements to false.
-
-    # Connection pooler in statement mode
-    {"hint":null,"details":null,"code":"08P01","message":"transaction blocks not allowed in statement pooling mode"}
-    Hint: Connection poolers in statement mode are not supported.
+  Enables or disables prepared statements. You should set it to ``false`` only when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction mode. See :ref:`connection_poolers`.
 
 .. _server-host:
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -39,6 +39,7 @@ db-anon-role             String                    Y
 db-pool                  Int     10
 db-pool-timeout          Int     10
 db-extra-search-path     String  public
+db-prepared-statements   Boolean True
 server-host              String  !4
 server-port              Int     3000
 server-unix-socket       String
@@ -132,6 +133,27 @@ db-extra-search-path
   This parameter was meant to make it easier to use **PostgreSQL extensions** (like PostGIS) that are outside of the :ref:`db-schema`.
 
   Multiple schemas can be added in a comma-separated string, e.g. ``public, extensions``.
+
+.. _db-prepared-statements:
+
+db-prepared-statements
+----------------------
+
+  Enables or disables prepared statements. You should set it to ``false`` when using PostgresSQL behind a connection pooler, like PgBouncer, working in transaction mode; this way, the statements will be parametrized but they will not be prepared.
+
+  Disabling this is not necessary when no transaction pooler is used or if one is working in session pooling mode. On the other hand, statement pooling mode is not compatible with PostgREST.
+
+  These are some errors you could get when using a connection pooler while this setting is enabled:
+
+  .. code-block::
+
+    # Connection pooler in transaction mode
+    {"hint":null,"details":null,"code":"42P05","message":"prepared statement \"0\" already exists"}
+    Hint: If you are using connection poolers in transaction mode, try setting db-prepared-statements to false.
+
+    # Connection pooler in statement mode
+    {"hint":null,"details":null,"code":"08P01","message":"transaction blocks not allowed in statement pooling mode"}
+    Hint: Connection poolers in statement mode are not supported.
 
 .. _server-host:
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -140,7 +140,11 @@ db-extra-search-path
 db-prepared-statements
 ----------------------
 
-  Enables or disables prepared statements. You should set it to ``false`` only when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction pooling mode; this way, the statements will be parameterized but they will not be prepared (expect to see a decrease in performance of around 23% according to our benchmarks). See :ref:`this section <connection_poolers>` for more information on using connection poolers.
+  Enables or disables prepared statements.
+
+  When disabled, the queries will be parameterized but they will not be prepared. In other words, the generated queries will be safe and invulnerable to SQL injection, but they will not be cached at the database server side. Not using prepared statements will noticeably decrease performance (around 23% decrease according to our benchmarks), so it's recommended to always have this setting enabled.
+
+  You should only set this to ``false`` when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <connection_poolers>` for more information.
 
 .. _db-tx-end:
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -142,7 +142,7 @@ db-prepared-statements
 
   Enables or disables prepared statements.
 
-  When disabled, the queries will be parameterized but they will not be prepared. In other words, the generated queries will be safe and invulnerable to SQL injection, but they will not be cached at the database server side. Not using prepared statements will noticeably decrease performance (around 23% decrease according to our benchmarks), so it's recommended to always have this setting enabled.
+  When disabled, the generated queries will be parameterized (invulnerable to SQL injection) but they will not be prepared (cached in the database session). Not using prepared statements will noticeably decrease performance, so it's recommended to always have this setting enabled.
 
   You should only set this to ``false`` when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <connection_poolers>` for more information.
 

--- a/postgrest.dict
+++ b/postgrest.dict
@@ -88,6 +88,7 @@ ov
 passphrase
 Pelletier
 Petr
+PgBouncer
 pgcrypto
 pgjwt
 pgSQL

--- a/postgrest.dict
+++ b/postgrest.dict
@@ -95,6 +95,7 @@ phfts
 phraseto
 plainto
 plfts
+poolers
 PostGIS
 PostgreSQL
 PostgreSQL's

--- a/releases/upcoming.rst
+++ b/releases/upcoming.rst
@@ -16,6 +16,9 @@ Added
 * Allow :ref:`s_procs_variadic`.
   |br| -- `@wolfgangwalther <https://github.com/wolfgangwalther>`_
 
+* Allow :ref:`connection_poolers` in transaction mode.
+  |br| -- `@laurenceisla <https://github.com/laurenceisla>`_
+
 * Config options for showing a full OpenAPI output regardless of the JWT role privileges and for disabling it altogether. See :ref:`openapi-mode`.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
 

--- a/releases/upcoming.rst
+++ b/releases/upcoming.rst
@@ -22,6 +22,9 @@ Added
 * Config option for logging level. See :ref:`log-level`.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
 
+* Config option for disabling prepared statements when using connection poolers in transaction mode. See :ref:`db-prepared-statements`.
+  |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
+
 * Documentation improvements
 
   + Added the :ref:`OPTIONS requests <options_requests>` section.

--- a/releases/upcoming.rst
+++ b/releases/upcoming.rst
@@ -16,7 +16,7 @@ Added
 * Allow :ref:`s_procs_variadic`.
   |br| -- `@wolfgangwalther <https://github.com/wolfgangwalther>`_
 
-* Allow :ref:`connection_poolers` in transaction mode.
+* Allow :ref:`connection_poolers` such as PgBouncer in transaction pooling mode.
   |br| -- `@laurenceisla <https://github.com/laurenceisla>`_
 
 * Config options for showing a full OpenAPI output regardless of the JWT role privileges and for disabling it altogether. See :ref:`openapi-mode`.
@@ -25,7 +25,7 @@ Added
 * Config option for logging level. See :ref:`log-level`.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
 
-* Config option for disabling prepared statements when using connection poolers in transaction mode. See :ref:`db-prepared-statements`.
+* Config option for enabling or disabling prepared statements. See :ref:`db-prepared-statements`.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
 
 * Config option for specifying how to terminate the transactions (allowing rollbacks, useful for testing). See :ref:`db-tx-end`.


### PR DESCRIPTION
Added documentation on the `db-prepared-statements` config option according to: https://github.com/PostgREST/postgrest/pull/1633 and https://github.com/PostgREST/postgrest/pull/1888.
