### PR TITLE
Mention environment variables in the configuration section

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -60,6 +60,8 @@ role-claim-key           String  .role
 raw-media-types          String
 ======================== ======= ================= ========
 
+You can also set these configuration parameters using environment variables. They are capitalized, have a ``PGRST_`` prefix, and use underscores. For example: ``PGRST_DB_URI`` corresponds to ``db-uri``.
+
 .. _config_reloading:
 
 Configuration Reloading


### PR DESCRIPTION
I had a `docker-compose.yml` with some environment variables in it and I couldn't really find any mention of them when searching Google for `PGRST_DB_URI` (other than the example). I think this small addition will make that a bit more discoverable.