### PR TITLE
Add link and explanation to download the latest unreleased builds

### DIFF
--- a/ecosystem.rst
+++ b/ecosystem.rst
@@ -93,7 +93,6 @@ Client-Side Libraries
 * `postgrest-js <https://github.com/supabase/postgrest-js>`_ - TypeScript/JavaScript
 * `postgrest-kt <https://github.com/supabase/postgrest-kt>`_ - Kotlin
 * `postgrest-py <https://github.com/supabase/postgrest-py>`_ - Python
-* `postgrest-pyclient <https://github.com/datrium/postgrest-pyclient>`_ - Python
 * `postgrest-request <https://github.com/lewisjared/postgrest-request>`_ - JS, SuperAgent
 * `postgrest-rs <https://github.com/supabase/postgrest-rs>`_ - Rust
 * `postgrest-sharp-client <https://github.com/thejettdurham/postgrest-sharp-client>`_ (needs maintainer) - C#, RestSharp

--- a/releases/upcoming.rst
+++ b/releases/upcoming.rst
@@ -5,6 +5,9 @@
 Upcoming
 ========
 
+These are changes yet unreleased. If you'd like to try them out before a new official release, access `the list of CI runs <https://github.com/PostgREST/postgrest/actions/workflows/ci.yaml?query=branch%3Amain>`_
+and select the newest commit, then download the build from the Artifacts section at the bottom of the page (you'll need a GitHub account to download it).
+
 Added
 -----
 


### PR DESCRIPTION
Now that Nightlies are deprecated, the latest builds can be downloaded from the resulting Artifacts from CI runs.