### PR TITLE
Specify external connection pooler

### DIFF
--- a/admin.rst
+++ b/admin.rst
@@ -125,7 +125,7 @@ Nginx rate limiting is general and indiscriminate. To rate limit each authentica
 Using External Connection Poolers
 ---------------------------------
 
-In order to increase performance, PostgREST uses prepared statements by default. However, this setting is incompatible with connection poolers such as PgBouncer working in transaction pooling mode. In this case, you need to set the :ref:`db-prepared-statements` config option to ``false``. On the other hand, session pooling is fully compatible with PostgREST, while statement pooling is not compatible at all.
+PostgREST manages its :ref:`own pool of connections <db-pool>` and uses prepared statements by default in order to increase performance. However, this setting is incompatible with external connection poolers such as PgBouncer working in transaction pooling mode. In this case, you need to set the :ref:`db-prepared-statements` config option to ``false``. On the other hand, session pooling is fully compatible with PostgREST, while statement pooling is not compatible at all.
 
 .. note::
 

--- a/admin.rst
+++ b/admin.rst
@@ -120,10 +120,10 @@ The burst argument tells Nginx to start dropping requests if more than five queu
 
 Nginx rate limiting is general and indiscriminate. To rate limit each authenticated request individually you will need to add logic in a :ref:`Custom Validation <custom_validation>` function.
 
-.. _connection_poolers:
+.. _external_connection_poolers:
 
-Using Connection Poolers
-------------------------
+Using External Connection Poolers
+---------------------------------
 
 In order to increase performance, PostgREST uses prepared statements by default. However, this setting is incompatible with connection poolers such as PgBouncer working in transaction pooling mode. In this case, you need to set the :ref:`db-prepared-statements` config option to ``false``. On the other hand, session pooling is fully compatible with PostgREST, while statement pooling is not compatible at all.
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -158,7 +158,7 @@ db-channel-enabled
 
   When this is set to :code:`true`, the notification channel specified in :ref:`db-channel` is enabled.
 
-  You should set this to ``false`` when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <connection_poolers>` for more information.
+  You should set this to ``false`` when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <external_connection_poolers>` for more information.
 
 .. _db-prepared-statements:
 
@@ -169,7 +169,7 @@ db-prepared-statements
 
   When disabled, the generated queries will be parameterized (invulnerable to SQL injection) but they will not be prepared (cached in the database session). Not using prepared statements will noticeably decrease performance, so it's recommended to always have this setting enabled.
 
-  You should only set this to ``false`` when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <connection_poolers>` for more information.
+  You should only set this to ``false`` when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <external_connection_poolers>` for more information.
 
 .. _db-tx-end:
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -158,7 +158,7 @@ db-channel-enabled
 
   When this is set to :code:`true`, the notification channel specified in :ref:`db-channel` is enabled.
 
-  You should set this to ``false`` when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <external_connection_poolers>` for more information.
+  You should set this to ``false`` when using PostgresSQL behind an external connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <external_connection_poolers>` for more information.
 
 .. _db-prepared-statements:
 
@@ -169,7 +169,7 @@ db-prepared-statements
 
   When disabled, the generated queries will be parameterized (invulnerable to SQL injection) but they will not be prepared (cached in the database session). Not using prepared statements will noticeably decrease performance, so it's recommended to always have this setting enabled.
 
-  You should only set this to ``false`` when using PostgresSQL behind a connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <external_connection_poolers>` for more information.
+  You should only set this to ``false`` when using PostgresSQL behind an external connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <external_connection_poolers>` for more information.
 
 .. _db-tx-end:
 

--- a/releases/v8.0.0.rst
+++ b/releases/v8.0.0.rst
@@ -28,7 +28,7 @@ Added
 * Allow sending the header ``Prefer: headers-only`` to get a response with a ``Location`` header. See :ref:`insert_update`.
   |br| -- `@laurenceisla <https://github.com/laurenceisla>`_
 
-* Allow :ref:`connection_poolers` such as PgBouncer in transaction pooling mode.
+* Allow :ref:`external_connection_poolers` such as PgBouncer in transaction pooling mode.
   |br| -- `@laurenceisla <https://github.com/laurenceisla>`_
 
 * Allow :ref:`config_reloading` by sending a SIGUSR2 signal.


### PR DESCRIPTION
Specify that the connection poolers are external and not from PostgREST itself.
