### PR TITLE
Typo in api.rst

### DIFF
--- a/api.rst
+++ b/api.rst
@@ -1418,7 +1418,7 @@ Every API hosted by PostgREST automatically serves a full `OpenAPI <https://www.
 
 .. note::
 
-  By default, this output depends on the permissions of the role that is contained in the JWT role claim (or the :ref:`db-anon-role` if no JWT is sent). If you need to show all the endpoints disregarding the role's permissions, set the :ref:`openapi-mode` config to :code:`ignore_privileges`.
+  By default, this output depends on the permissions of the role that is contained in the JWT role claim (or the :ref:`db-anon-role` if no JWT is sent). If you need to show all the endpoints disregarding the role's permissions, set the :ref:`openapi-mode` config to :code:`ignore-privileges`.
 
 For extra customization, the OpenAPI output contains a "description" field for every `SQL comment <https://www.postgresql.org/docs/current/sql-comment.html>`_ on any database object. For instance,
 


### PR DESCRIPTION
The correct setting name is `ignore-privileges`, with dash in between the words.
Docs:
https://postgrest.org/en/v8.0/configuration.html?highlight=openapi%203#openapi-mode

<!--
When adding a new doc section or page, please add an entry to releases/upcoming.rst.
-->
