### PR TITLE
Allow rpc POST with single unnamed parameter

### DIFF
--- a/api.rst
+++ b/api.rst
@@ -1877,9 +1877,9 @@ To send raw JSON, you can avoid using the ``Prefer: params=single-object`` heade
 
 .. note::
 
-  If an overloaded function has a single ``json`` or ``jsonb`` unnamed parameter, PostgREST will call this function as a fallback provided that no other overloaded function is found with the parameters sent in the request.
+  If an overloaded function has a single ``json`` or ``jsonb`` unnamed parameter, PostgREST will call this function as a fallback provided that no other overloaded function is found with the parameters sent in the POST request.
 
-To upload raw binary, the parameter type must be ``bytea`` and the header ``Content-Type: application/octet-stream`` must be included in the request. Similarly, to upload raw text, the parameter type must be ``text`` and the header ``Content-Type: text/plain`` must be included in the request.
+To send raw binary, the parameter type must be ``bytea`` and the header ``Content-Type: application/octet-stream`` must be included in the request. Similarly, to send raw text, the parameter type must be ``text`` and the header ``Content-Type: text/plain`` must be included in the request.
 
 .. _s_procs_array:
 

--- a/api.rst
+++ b/api.rst
@@ -1848,12 +1848,7 @@ Calling functions with a single unnamed parameter
 
 You can make a POST request to a function with a single unnamed parameter to send raw ``json/jsonb``, ``bytea`` or ``text`` data.
 
-.. _s_proc_single_unnamed_json:
-
-Uploading JSON to a function
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can avoid using the ``Prefer: params=single-object`` header to send the JSON object as a single argument. To that end, the function must have a single unnamed JSON parameter and the header ``Content-Type: application/json`` must be set on the request.
+To send raw ``json/jsonb``, you can avoid using the ``Prefer: params=single-object`` header if the function has a single unnamed JSON parameter and the header ``Content-Type: application/json`` is included in the request.
 
 .. code-block:: plpgsql
 
@@ -1880,19 +1875,7 @@ You can avoid using the ``Prefer: params=single-object`` header to send the JSON
 
   8
 
-.. _s_proc_single_unnamed_binary:
-
-Uploading binary to a function
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can upload a binary to a function that takes a single unnamed parameter of type ``bytea`` by sending the header :code:`Content-Type: application/octet-stream` with your request.
-
-.. _s_proc_single_unnamed_text:
-
-Uploading raw text to a function
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can upload raw text to a function that takes a single unnamed parameter of type ``text`` by sending the header :code:`Content-Type: text/plain` with your request.
+To upload raw binary the parameter type must be ``bytea`` and the header ``Content-Type: application/octet-stream`` must be included in the request. Similarly, to upload raw text the parameter type must be ``text`` and the header ``Content-Type: text/plain`` must be included in the request.
 
 .. _s_procs_array:
 

--- a/api.rst
+++ b/api.rst
@@ -1318,10 +1318,17 @@ You can also call a function that takes a single parameter of type JSON by sendi
 
   8
 
+.. _s_proc_single_unnamed:
+
+Calling functions with a single unnamed parameter
+-------------------------------------------------
+
+You can make a POST request to a function with a single unnamed parameter to send raw ``json/jsonb``, ``bytea`` or ``text`` data.
+
 .. _s_proc_single_unnamed_json:
 
-Using an unnamed JSON parameter
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Uploading JSON to a function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can avoid using the ``Prefer: params=single-object`` header to send the JSON object as a single argument. To that end, the function must have a single unnamed JSON parameter and the header ``Content-Type: application/json`` must be set on the request.
 
@@ -1355,14 +1362,14 @@ You can avoid using the ``Prefer: params=single-object`` header to send the JSON
 .. _s_proc_single_unnamed_binary:
 
 Uploading binary to a function
-------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can upload a binary to a function that takes a single unnamed parameter of type ``bytea`` by sending the header :code:`Content-Type: application/octet-stream` with your request.
 
 .. _s_proc_single_unnamed_text:
 
 Uploading raw text to a function
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can upload raw text to a function that takes a single unnamed parameter of type ``text`` by sending the header :code:`Content-Type: text/plain` with your request.
 

--- a/api.rst
+++ b/api.rst
@@ -1296,6 +1296,8 @@ Because ``add_them`` is ``IMMUTABLE``, we can alternately call the function with
 
 The function parameter names match the JSON object keys in the POST case, for the GET case they match the query parameters ``?a=1&b=2``.
 
+.. _s_proc_single_json:
+
 Calling functions with a single JSON parameter
 ----------------------------------------------
 
@@ -1315,6 +1317,54 @@ You can also call a function that takes a single parameter of type JSON by sendi
   { "x": 4, "y": 2 }
 
   8
+
+.. _s_proc_single_unnamed_json:
+
+Using an unnamed JSON parameter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can avoid using the ``Prefer: params=single-object`` header to send the JSON object as a single argument. To that end, the function must have a single unnamed JSON parameter and the header ``Content-Type: application/json`` must be set on the request.
+
+.. code-block:: plpgsql
+
+  CREATE FUNCTION mult_them(json) RETURNS int AS $$
+    SELECT ($1->>'x')::int * ($1->>'y')::int
+  $$ LANGUAGE SQL;
+
+.. code-block:: http
+
+  POST /rpc/mult_them HTTP/1.1
+  Content-Type: application/json
+
+  { "x": 4, "y": 2 }
+
+  8
+
+.. _s_proc_single_unnamed_json_overloaded:
+
+.. important::
+
+  Functions with a single unnamed JSON parameter must **not** be overloaded, otherwise PostgREST will not be able to resolve a POST request to the function and will send this response:
+
+  .. code-block:: http
+
+   HTTP/1.1 300 Multiple Choices
+
+  To solve this, rename the function itself or name the unnamed parameter.
+
+.. _s_proc_single_unnamed_binary:
+
+Uploading binary to a function
+------------------------------
+
+You can upload a binary to a function that takes a single unnamed parameter of type ``bytea`` by sending the header :code:`Content-Type: application/octet-stream` with your request.
+
+.. _s_proc_single_unnamed_text:
+
+Uploading raw text to a function
+--------------------------------
+
+You can upload raw text to a function that takes a single unnamed parameter of type ``text`` by sending the header :code:`Content-Type: text/plain` with your request.
 
 .. _s_procs_array:
 

--- a/api.rst
+++ b/api.rst
@@ -1848,7 +1848,7 @@ Calling functions with a single unnamed parameter
 
 You can make a POST request to a function with a single unnamed parameter to send raw ``json/jsonb``, ``bytea`` or ``text`` data.
 
-To send raw ``json/jsonb``, you can avoid using the ``Prefer: params=single-object`` header if the function has a single unnamed JSON parameter and the header ``Content-Type: application/json`` is included in the request.
+To send raw JSON, you can avoid using the ``Prefer: params=single-object`` header if the function has a single unnamed ``json`` or ``jsonb`` parameter and the header ``Content-Type: application/json`` is included in the request.
 
 .. code-block:: plpgsql
 
@@ -1875,7 +1875,11 @@ To send raw ``json/jsonb``, you can avoid using the ``Prefer: params=single-obje
 
   8
 
-To upload raw binary the parameter type must be ``bytea`` and the header ``Content-Type: application/octet-stream`` must be included in the request. Similarly, to upload raw text the parameter type must be ``text`` and the header ``Content-Type: text/plain`` must be included in the request.
+.. note::
+
+  If an overloaded function has a single ``json`` or ``jsonb`` unnamed parameter, PostgREST will call this function as a fallback provided that no other overloaded function is found with the parameters sent in the request.
+
+To upload raw binary, the parameter type must be ``bytea`` and the header ``Content-Type: application/octet-stream`` must be included in the request. Similarly, to upload raw text, the parameter type must be ``text`` and the header ``Content-Type: text/plain`` must be included in the request.
 
 .. _s_procs_array:
 

--- a/api.rst
+++ b/api.rst
@@ -1861,12 +1861,22 @@ You can avoid using the ``Prefer: params=single-object`` header to send the JSON
     SELECT ($1->>'x')::int * ($1->>'y')::int
   $$ LANGUAGE SQL;
 
-.. code-block:: http
+.. tabs::
 
-  POST /rpc/mult_them HTTP/1.1
-  Content-Type: application/json
+  .. code-tab:: http
 
-  { "x": 4, "y": 2 }
+    POST /rpc/mult_them HTTP/1.1
+    Content-Type: application/json
+
+    { "x": 4, "y": 2 }
+
+  .. code-tab:: bash Curl
+
+    curl "http://localhost:3000/rpc/mult_them" \
+      -X POST -H "Content-Type: application/json" \
+      -d '{ "x": 4, "y": 2 }'
+
+.. code-block:: json
 
   8
 

--- a/api.rst
+++ b/api.rst
@@ -1347,18 +1347,6 @@ You can avoid using the ``Prefer: params=single-object`` header to send the JSON
 
   8
 
-.. _s_proc_single_unnamed_json_overloaded:
-
-.. important::
-
-  Functions with a single unnamed JSON parameter must **not** be overloaded, otherwise PostgREST will not be able to resolve a POST request to the function and will send this response:
-
-  .. code-block:: http
-
-   HTTP/1.1 300 Multiple Choices
-
-  To solve this, rename the function itself or name the unnamed parameter.
-
 .. _s_proc_single_unnamed_binary:
 
 Uploading binary to a function

--- a/releases/upcoming.rst
+++ b/releases/upcoming.rst
@@ -35,6 +35,9 @@ Added
 * Add ``Retry-After`` header when recovering the connection. See :ref:`automatic_recovery`.
   |br| -- `@gautam1168 <https://github.com/gautam1168>`_
 
+* Allow calling a function with a single unnamed parameter to POST raw :ref:`json/jsonb <s_proc_single_unnamed_json>`, :ref:`bytea <s_proc_single_unnamed_binary>` or :ref:`text <s_proc_single_unnamed_text>`.
+  |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
+
 * Documentation improvements
 
   + Added :ref:`nested_embedding` to the :ref:`resource_embedding` section.
@@ -43,4 +46,10 @@ Fixed
 -----
 
 * Fix using single double quotes (``"``) and backslashes (``/``) as values on the "in" operator
+  |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
+
+Changed
+-------
+
+* Functions with a single unnamed JSON parameter :ref:`must not be overloaded <s_proc_single_unnamed_json_overloaded>` for POST requests to be made to them.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_

--- a/releases/upcoming.rst
+++ b/releases/upcoming.rst
@@ -35,7 +35,7 @@ Added
 * Add ``Retry-After`` header when recovering the connection. See :ref:`automatic_recovery`.
   |br| -- `@gautam1168 <https://github.com/gautam1168>`_
 
-* Allow calling a function with a single unnamed parameter to POST raw :ref:`json/jsonb <s_proc_single_unnamed_json>`, :ref:`bytea <s_proc_single_unnamed_binary>` or :ref:`text <s_proc_single_unnamed_text>`.
+* Allow calling a function with a :ref:`single unnamed parameter <s_proc_single_unnamed>` to POST raw ``json/jsonb``, ``bytea`` or ``text``.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
 
 * Documentation improvements

--- a/releases/upcoming.rst
+++ b/releases/upcoming.rst
@@ -47,9 +47,3 @@ Fixed
 
 * Fix using single double quotes (``"``) and backslashes (``/``) as values on the "in" operator
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
-
-Changed
--------
-
-* Functions with a single unnamed JSON parameter :ref:`must not be overloaded <s_proc_single_unnamed_json_overloaded>` for POST requests to be made to them.
-  |br| -- `@steve-chavez <https://github.com/steve-chavez>`_


### PR DESCRIPTION
Documentation for https://github.com/PostgREST/postgrest/pull/1927

Replaces https://github.com/PostgREST/postgrest-docs/pull/431