### PR TITLE
Add the logical operators section in horizontal filtering

### DIFF
--- a/api.rst
+++ b/api.rst
@@ -51,30 +51,6 @@ Multiple parameters can be logically conjoined by:
 
     curl "http://localhost:3000/people?age=gte.18&student=is.true"
 
-Multiple parameters can be logically disjoined by:
-
-.. tabs::
-
-  .. code-tab:: http
-
-    GET /people?or=(age.gte.14,age.lte.18) HTTP/1.1
-
-  .. code-tab:: bash Curl
-
-    curl "http://localhost:3000/people?or=(age.gte.14,age.lte.18)"
-
-Complex logic can also be applied:
-
-.. tabs::
-
-  .. code-tab:: http
-
-    GET /people?and=(grade.gte.90,student.is.true,or(age.gte.14,age.is.null)) HTTP/1.1
-
-  .. code-tab:: bash Curl
-
-    curl "http://localhost:3000/people?and=(grade.gte.90,student.is.true,or(age.gte.14,age.is.null))"
-
 .. _operators:
 
 Operators
@@ -111,10 +87,10 @@ sr            :code:`>>`                strictly right of
 nxr           :code:`&<`                does not extend to the right of, e.g. :code:`?range=nxr.(1,10)`
 nxl           :code:`&>`                does not extend to the left of
 adj           :code:`-|-`               is adjacent to, e.g. :code:`?range=adj.(1,10)`
-not           :code:`NOT`               negates another operator, see below
+and           :code:`AND`               logical :code:`AND`, see :ref:`logical_operators`
+or            :code:`OR`                logical :code:`OR`, see :ref:`logical_operators`
+not           :code:`NOT`               negates another operator, see :ref:`logical_operators`
 ============  ========================  ==================================================================================
-
-To negate any operator, prefix it with :code:`not` like :code:`?a=not.eq.2` or :code:`?not.and=(a.gte.0,a.lte.100)` .
 
 For more complicated filters you will have to create a new view in the database, or use a stored procedure. For instance, here's a view to show "today's stories" including possibly older pinned stories:
 
@@ -138,6 +114,49 @@ The view will provide a new endpoint:
   .. code-tab:: bash Curl
 
     curl "http://localhost:3000/fresh_stories"
+
+.. _logical_operators:
+
+Logical operators
+~~~~~~~~~~~~~~~~~
+
+Multiple parameters can be logically **conjoined** using ``and``:
+
+.. tabs::
+
+  .. code-tab:: http
+
+    GET /people?and=(age.gte.18,student.is.true) HTTP/1.1
+
+  .. code-tab:: bash Curl
+
+    curl "http://localhost:3000/people?and=(age.gte.18,student.is.true)"
+
+Multiple parameters can be logically **disjoined** using ``or``:
+
+.. tabs::
+
+  .. code-tab:: http
+
+    GET /people?or=(age.gte.14,age.lte.18) HTTP/1.1
+
+  .. code-tab:: bash Curl
+
+    curl "http://localhost:3000/people?or=(age.gte.14,age.lte.18)"
+
+Complex logic can also be applied:
+
+.. tabs::
+
+  .. code-tab:: http
+
+    GET /people?and=(grade.gte.90,student.is.true,or(age.gte.14,age.is.null)) HTTP/1.1
+
+  .. code-tab:: bash Curl
+
+    curl "http://localhost:3000/people?and=(grade.gte.90,student.is.true,or(age.gte.14,age.is.null))"
+
+To **negate** any operator, prefix it with :code:`not` like :code:`?a=not.eq.2` or :code:`?not.and=(a.gte.0,a.lte.100)` .
 
 .. _fts:
 

--- a/api.rst
+++ b/api.rst
@@ -87,9 +87,9 @@ sr            :code:`>>`                strictly right of
 nxr           :code:`&<`                does not extend to the right of, e.g. :code:`?range=nxr.(1,10)`
 nxl           :code:`&>`                does not extend to the left of
 adj           :code:`-|-`               is adjacent to, e.g. :code:`?range=adj.(1,10)`
-and           :code:`AND`               logical :code:`AND`, see :ref:`logical_operators`
-or            :code:`OR`                logical :code:`OR`, see :ref:`logical_operators`
 not           :code:`NOT`               negates another operator, see :ref:`logical_operators`
+or            :code:`OR`                logical :code:`OR`, see :ref:`logical_operators`
+and           :code:`AND`               logical :code:`AND`, see :ref:`logical_operators`
 ============  ========================  ==================================================================================
 
 For more complicated filters you will have to create a new view in the database, or use a stored procedure. For instance, here's a view to show "today's stories" including possibly older pinned stories:

--- a/api.rst
+++ b/api.rst
@@ -27,7 +27,7 @@ There are no deeply/nested/routes. Each route provides OPTIONS, GET, HEAD, POST,
 Horizontal Filtering (Rows)
 ---------------------------
 
-You can filter result rows by adding conditions on columns, each condition a query string parameter. For instance, to return people aged under 13 years old:
+You can filter result rows by adding conditions on columns. For instance, to return people aged under 13 years old:
 
 .. tabs::
 
@@ -39,7 +39,7 @@ You can filter result rows by adding conditions on columns, each condition a que
 
     curl "http://localhost:3000/people?age=lt.13"
 
-Multiple parameters can be logically conjoined by:
+You can evaluate multiple conditions on columns by adding more query string parameters. For instance, to return people who are 18 or older **and** are students:
 
 .. tabs::
 
@@ -120,43 +120,31 @@ The view will provide a new endpoint:
 Logical operators
 ~~~~~~~~~~~~~~~~~
 
-Multiple parameters can be logically **conjoined** using ``and``:
+Multiple conditions on columns are evaluated using ``AND`` by default, but you can combine them using ``OR`` with the ``or`` operator. For example, to return people under 18 **or** over 21:
 
 .. tabs::
 
   .. code-tab:: http
 
-    GET /people?and=(age.gte.18,student.is.true) HTTP/1.1
+    GET /people?or=(age.lt.18,age.gt.21) HTTP/1.1
 
   .. code-tab:: bash Curl
 
-    curl "http://localhost:3000/people?and=(age.gte.18,student.is.true)"
+    curl "http://localhost:3000/people?or=(age.lt.18,age.gt.21)"
 
-Multiple parameters can be logically **disjoined** using ``or``:
+To **negate** any operator, you can prefix it with :code:`not` like :code:`?a=not.eq.2` or :code:`?not.and=(a.gte.0,a.lte.100)` .
+
+You can also apply complex logic to the conditions:
 
 .. tabs::
 
   .. code-tab:: http
 
-    GET /people?or=(age.gte.14,age.lte.18) HTTP/1.1
+    GET /people?people?grade=gte.90&student=is.true&or=(age.eq.14,not.and=(age.gte.11,age.lte.17)) HTTP/1.1
 
   .. code-tab:: bash Curl
 
-    curl "http://localhost:3000/people?or=(age.gte.14,age.lte.18)"
-
-Complex logic can also be applied:
-
-.. tabs::
-
-  .. code-tab:: http
-
-    GET /people?and=(grade.gte.90,student.is.true,or(age.gte.14,age.is.null)) HTTP/1.1
-
-  .. code-tab:: bash Curl
-
-    curl "http://localhost:3000/people?and=(grade.gte.90,student.is.true,or(age.gte.14,age.is.null))"
-
-To **negate** any operator, prefix it with :code:`not` like :code:`?a=not.eq.2` or :code:`?not.and=(a.gte.0,a.lte.100)` .
+    curl "http://localhost:3000/people?grade=gte.90&student=is.true&or=(age.eq.14,not.and(age.gte.11,age.lte.17))"
 
 .. _fts:
 

--- a/api.rst
+++ b/api.rst
@@ -140,7 +140,7 @@ You can also apply complex logic to the conditions:
 
   .. code-tab:: http
 
-    GET /people?people?grade=gte.90&student=is.true&or=(age.eq.14,not.and=(age.gte.11,age.lte.17)) HTTP/1.1
+    GET /people?grade=gte.90&student=is.true&or=(age.eq.14,not.and(age.gte.11,age.lte.17)) HTTP/1.1
 
   .. code-tab:: bash Curl
 

--- a/postgrest.dict
+++ b/postgrest.dict
@@ -27,7 +27,6 @@ Daemonizing
 DDL
 DevOps
 DiBiase
-disjoined
 dockerize
 DoS
 eq

--- a/releases/upcoming.rst
+++ b/releases/upcoming.rst
@@ -42,6 +42,7 @@ Added
 
   + Added :ref:`nested_embedding` to the :ref:`resource_embedding` section.
   + Added the :ref:`templates` section to the :doc:`Ecosystem </ecosystem>`.
+  + Added the :ref:`logical_operators` section
 
 Fixed
 -----


### PR DESCRIPTION
The `and` and `or` operators are somewhat "hidden" in the Horizontal Filtering section. This PR groups them in a subheading and adds them to the operator list.