### PR TITLE
Add missing = in log-level docs

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -272,7 +272,7 @@ log-level
       log-level = "warn"
 
       # All the "warn" level events plus all requests (every status code) are logged
-      log-level  "info"
+      log-level = "info"
 
 
   Because currently there's no buffering for logging, the levels with minimal logging(``crit/error``) will increase throughput.


### PR DESCRIPTION
<!--
When adding a new doc section or page, please add an entry to releases/upcoming.rst.
-->

I saw this typo when I was reviewing the configuration documentation