### PR TITLE
Update configuration page

### DIFF
--- a/admin.rst
+++ b/admin.rst
@@ -266,7 +266,7 @@ First, create postgrest configuration in ``/etc/postgrest/config``
 .. code-block:: ini
 
   db-uri = "postgres://<your_user>:<your_password>@localhost:5432/<your_db>"
-  db-schema = "<your_exposed_schema>"
+  db-schemas = "<your_exposed_schema>"
   db-anon-role = "<your_anon_role>"
   db-pool = 10
 

--- a/api.rst
+++ b/api.rst
@@ -396,7 +396,7 @@ As mentioned, computed columns do not appear in the output by default. However y
 
 .. important::
 
-  Computed columns must be created under the :ref:`exposed schema <db-schema>` to be used in this way.
+  Computed columns must be created under the :ref:`exposed schema <db-schemas>` to be used in this way.
 
 Unicode support
 ---------------
@@ -666,9 +666,9 @@ In general, when having smaller row-counts, the estimated count should be as clo
 
 To help with these cases, PostgREST can get the exact count up until a threshold and get the planned count when
 that threshold is surpassed. To use this behavior, you can specify the ``Prefer: count=estimated`` header. The **threshold** is
-defined by :ref:`max-rows`.
+defined by :ref:`db-max-rows`.
 
-Here's an example. Suppose we set ``max-rows=1000`` and ``smalltable`` has 321 rows, then we'll get the exact count:
+Here's an example. Suppose we set ``db-max-rows=1000`` and ``smalltable`` has 321 rows, then we'll get the exact count:
 
 .. tabs::
 
@@ -1156,7 +1156,7 @@ It's also possible to embed `Materialized Views <https://www.postgresql.org/docs
 Embedding Chains of Views
 -------------------------
 
-Views can also depend on other views, which in turn depend on the actual source table. For PostgREST to pick up those chains recursively to any depth, all the views must be in the search path, so either in the exposed schema (:ref:`db-schema`) or in one of the schemas set in :ref:`db-extra-search-path`. This does not apply to the source table, which could be in a private schema as well. See :ref:`schema_isolation` for more details.
+Views can also depend on other views, which in turn depend on the actual source table. For PostgREST to pick up those chains recursively to any depth, all the views must be in the search path, so either in the exposed schema (:ref:`db-schemas`) or in one of the schemas set in :ref:`db-extra-search-path`. This does not apply to the source table, which could be in a private schema as well. See :ref:`schema_isolation` for more details.
 
 .. _s_proc_embed:
 
@@ -2399,7 +2399,7 @@ PostgREST sets highly permissive cross origin resource sharing, that is why it a
 Switching Schemas
 =================
 
-You can switch schemas at runtime with the ``Accept-Profile`` and ``Content-Profile`` headers. You can only switch to a schema that is included in :ref:`db-schema`.
+You can switch schemas at runtime with the ``Accept-Profile`` and ``Content-Profile`` headers. You can only switch to a schema that is included in :ref:`db-schemas`.
 
 For GET or HEAD, the schema to be used can be selected through the ``Accept-Profile`` header:
 
@@ -2516,7 +2516,7 @@ Notice that the variable should be set to an *array* of single-key objects rathe
 Setting headers via pre-request
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By using a :ref:`pre-request` function, you can add headers to GET/POST/PATCH/PUT/DELETE responses.
+By using a :ref:`db-pre-request` function, you can add headers to GET/POST/PATCH/PUT/DELETE responses.
 As an example, let's add some cache headers for all requests that come from an Internet Explorer(6 or 7) browser.
 
 .. code-block:: postgresql
@@ -2532,7 +2532,7 @@ As an example, let's add some cache headers for all requests that come from an I
    end; $$ language plpgsql;
 
    -- set this function on postgrest.conf
-   -- pre-request = custom_headers
+   -- db-pre-request = custom_headers
 
 Now when you make a GET request to a table or view, you'll get the cache headers.
 

--- a/auth.rst
+++ b/auth.rst
@@ -122,13 +122,13 @@ You can mix the group and individual role policies. For instance we could still 
 Custom Validation
 -----------------
 
-PostgREST honors the :code:`exp` claim for token expiration, rejecting expired tokens. However it does not enforce any extra constraints. An example of an extra constraint would be to immediately revoke access for a certain user. The configuration file parameter :code:`pre-request` specifies a stored procedure to call immediately after the authenticator switches into a new role and before the main query itself runs.
+PostgREST honors the :code:`exp` claim for token expiration, rejecting expired tokens. However it does not enforce any extra constraints. An example of an extra constraint would be to immediately revoke access for a certain user. The configuration file parameter :code:`db-pre-request` specifies a stored procedure to call immediately after the authenticator switches into a new role and before the main query itself runs.
 
 Here's an example. In the config file specify a stored procedure:
 
 .. code:: ini
 
-  pre-request = "public.check_user"
+  db-pre-request = "public.check_user"
 
 In the function you can run arbitrary code to check the request and raise an exception to block it if desired.
 
@@ -226,7 +226,7 @@ To use Auth0, create `an application <https://auth0.com/docs/get-started/applica
     function (user, context, callback) {
 
       // Follow the documentations at
-      // https://postgrest.org/en/latest/configuration.html#role-claim-key
+      // https://postgrest.org/en/latest/configuration.html#db-role-claim-key
       // to set a custom role claim on PostgREST
       // and use it as custom claim attribute in this rule
       const myRoleClaim = 'https://myapp.com/role';

--- a/configuration.rst
+++ b/configuration.rst
@@ -24,377 +24,13 @@ The configuration file must contain a set of key value pairs. At minimum you mus
   db-uri       = "postgres://user:pass@host:5432/dbname"
 
   # The name of which database schema to expose to REST clients
-  db-schema    = "api"
+  db-schemas   = "api"
 
   # The database role to use when no client authentication is provided.
   # Can (and should) differ from user in db-uri
   db-anon-role = "anon"
 
 The user specified in the db-uri is also known as the authenticator role. For more information about the anonymous vs authenticator roles see the :ref:`roles`.
-
-.. _config_full_list:
-
-Here is the full list of configuration parameters.
-
-======================== ======= ================= ========
-Name                     Type    Default           Required
-======================== ======= ================= ========
-db-uri                   String                    Y
-db-schema                String                    Y
-db-anon-role             String                    Y
-db-pool                  Int     10
-db-pool-timeout          Int     10
-db-extra-search-path     String  public
-db-channel               String  pgrst
-db-channel-enabled       Boolean True
-db-prepared-statements   Boolean True
-db-tx-end                String  commit
-db-config                Boolean True
-db-use-legacy-gucs       Boolean True
-server-host              String  !4
-server-port              Int     3000
-server-unix-socket       String
-server-unix-socket-mode  String  660
-log-level                String  error
-openapi-mode             String  follow-privileges
-openapi-server-proxy-uri String
-jwt-secret               String
-jwt-aud                  String
-secret-is-base64         Boolean False
-max-rows                 Int     ∞
-pre-request              String
-app.settings.*           String
-role-claim-key           String  .role
-raw-media-types          String
-======================== ======= ================= ========
-
-.. _db-uri:
-
-db-uri
-------
-
-  The standard connection PostgreSQL `URI format <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING>`_. Symbols and unusual characters in the password or other fields should be percent encoded to avoid a parse error. If enforcing an SSL connection to the database is required you can use `sslmode <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS>`_ in the URI, for example ``postgres://user:pass@host:5432/dbname?sslmode=require``.
-
-  When running PostgREST on the same machine as PostgreSQL, it is also possible to connect to the database using a `Unix socket <https://en.wikipedia.org/wiki/Unix_domain_socket>`_ and the `Peer Authentication method <https://www.postgresql.org/docs/current/auth-peer.html>`_ as an alternative to TCP/IP communication and authentication with a password, this also grants higher performance.  To do this you can omit the host and the password, e.g. ``postgres://user@/dbname``, see the `libpq connection string <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING>`_ documentation for more details.
-
-  On older systems like Centos 6, with older versions of libpq, a different db-uri syntax has to be used. In this case the URI is a string of space separated key-value pairs (key=value), so the example above would be :code:`"host=host user=user port=5432 dbname=dbname password=pass"`.
-
-  Choosing a value for this parameter beginning with the at sign such as ``@filename`` (e.g. ``@./configs/my-config``) loads the secret out of an external file.
-
-
-.. _db-schema:
-
-db-schema
----------
-
-  The database schema to expose to REST clients. Tables, views and stored procedures in this schema will get API endpoints.
-
-  .. code:: bash
-
-     db-schema = "api"
-
-  This schema gets added to the `search_path <https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH>`_ of every request.
-
-List of schemas
-~~~~~~~~~~~~~~~
-
-  You can also specify a list of schemas that can be used for **schema-based multitenancy** and **api versioning** by :ref:`multiple-schemas`. Example:
-
-  .. code:: bash
-
-     db-schema = "tenant1, tenant2"
-
-  If you don't :ref:`Switch Schemas <multiple-schemas>`, the first schema in the list(``tenant1`` in this case) is chosen as the default schema.
-
-  *Only the chosen schema* gets added to the `search_path <https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH>`_ of every request.
-
-  .. warning::
-
-     Never expose private schemas in this way. See :ref:`schema_isolation`.
-
-.. _db-anon-role:
-
-db-anon-role
-------------
-
-  The database role to use when executing commands on behalf of unauthenticated clients. For more information, see :ref:`roles`.
-
-.. _db-pool:
-
-db-pool
--------
-
-  Number of connections to keep open in PostgREST's database pool. Having enough here for the maximum expected simultaneous client connections can improve performance. Note it's pointless to set this higher than the :code:`max_connections` GUC in your database.
-
-.. _db-pool-timeout:
-
-db-pool-timeout
----------------
-
-   Time to live, in seconds, for an idle database pool connection. If the timeout is reached the connection will be closed.
-   Once a new request arrives a new connection will be started.
-
-.. _db-extra-search-path:
-
-db-extra-search-path
---------------------
-
-  Extra schemas to add to the `search_path <https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH>`_ of every request. These schemas tables, views and stored procedures **don't get API endpoints**, they can only be referred from the database objects inside your :ref:`db-schema`.
-
-  This parameter was meant to make it easier to use **PostgreSQL extensions** (like PostGIS) that are outside of the :ref:`db-schema`.
-
-  Multiple schemas can be added in a comma-separated string, e.g. ``public, extensions``.
-
-.. _db-channel:
-
-db-channel
-----------
-
-  The name of the notification channel that PostgREST uses for :ref:`schema_reloading` and configuration reloading.
-
-.. _db-channel-enabled:
-
-db-channel-enabled
-------------------
-
-  When this is set to :code:`true`, the notification channel specified in :ref:`db-channel` is enabled.
-
-  You should set this to ``false`` when using PostgresSQL behind an external connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <external_connection_poolers>` for more information.
-
-.. _db-prepared-statements:
-
-db-prepared-statements
-----------------------
-
-  Enables or disables prepared statements.
-
-  When disabled, the generated queries will be parameterized (invulnerable to SQL injection) but they will not be prepared (cached in the database session). Not using prepared statements will noticeably decrease performance, so it's recommended to always have this setting enabled.
-
-  You should only set this to ``false`` when using PostgresSQL behind an external connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <external_connection_poolers>` for more information.
-
-.. _db-tx-end:
-
-db-tx-end
----------
-
-  Specifies how to terminate the database transactions.
-
-  .. code:: bash
-
-    # The transaction is always committed
-    db-tx-end = "commit"
-
-    # The transaction is committed unless a "Prefer: tx=rollback" header is sent
-    db-tx-end = "commit-allow-override"
-
-    # The transaction is always rolled back
-    db-tx-end = "rollback"
-
-    # The transaction is rolled back unless a "Prefer: tx=commit" header is sent
-    db-tx-end = "rollback-allow-override"
-
-.. _db-config:
-
-db-config
----------
-
-   Enables the in-database configuration.
-
-.. _db-use-legacy-gucs:
-
-db-use-legacy-gucs
-------------------
-
-  Determine if GUC request settings for headers, cookies and jwt claims use the `legacy names <https://postgrest.org/en/v8.0/api.html#accessing-request-headers-cookies-and-jwt-claims>`_ (string with dashes, invalid starting from PostgreSQL v14) with text values instead of the :ref:`new names <guc_req_headers_cookies_claims>` (string without dashes, valid on all PostgreSQL versions) with json values.
-
-  On PostgreSQL versions 14 and above, this parameter is ignored.
-
-.. _server-host:
-
-server-host
------------
-
-  Where to bind the PostgREST web server. In addition to the usual address options, PostgREST interprets these reserved addresses with special meanings:
-
-  * :code:`*` - any IPv4 or IPv6 hostname
-  * :code:`*4` - any IPv4 or IPv6 hostname, IPv4 preferred
-  * :code:`!4` - any IPv4 hostname
-  * :code:`*6` - any IPv4 or IPv6 hostname, IPv6 preferred
-  * :code:`!6` - any IPv6 hostname
-
-.. _server-port:
-
-server-port
------------
-
-  The TCP port to bind the web server.
-
-.. _server-unix-socket:
-
-server-unix-socket
-------------------
-
-  `Unix domain socket <https://en.wikipedia.org/wiki/Unix_domain_socket>`_ where to bind the PostgREST web server.
-  If specified, this takes precedence over :ref:`server-port`. Example:
-
-  .. code:: bash
-
-    server-unix-socket = "/tmp/pgrst.sock"
-
-.. _server-unix-socket-mode:
-
-server-unix-socket-mode
------------------------
-
-  `Unix file mode <https://en.wikipedia.org/wiki/File_system_permissions>`_ to be set for the socket specified in :ref:`server-unix-socket`
-  Needs to be a valid octal between 600 and 777.
-
-  .. code:: bash
-
-    server-unix-socket-mode = "660"
-
-.. _log-level:
-
-log-level
----------
-
-  Specifies the level of information to be logged while running PostgREST.
-
-  .. code:: bash
-
-      # Only startup and db connection recovery messages are logged
-      log-level = "crit"
-
-      # All the "crit" level events plus server errors (status 5xx) are logged
-      log-level = "error"
-
-      # All the "error" level events plus request errors (status 4xx) are logged
-      log-level = "warn"
-
-      # All the "warn" level events plus all requests (every status code) are logged
-      log-level = "info"
-
-
-  Because currently there's no buffering for logging, the levels with minimal logging(``crit/error``) will increase throughput.
-
-.. _openapi-mode:
-
-openapi-mode
-------------
-
-  Specifies how the OpenAPI output should be displayed.
-
-  .. code:: bash
-
-    # Follows the privileges of the JWT role claim (or from db-anon-role if the JWT is not sent)
-    # Shows information depending on the permissions that the role making the request has
-    openapi-mode = "follow-privileges"
-
-    # Ignores the privileges of the JWT role claim (or from db-anon-role if the JWT is not sent)
-    # Shows all the exposed information, regardless of the permissions that the role making the request has
-    openapi-mode = "ignore-privileges"
-
-    # Disables the OpenApi output altogether.
-    # Throws a `404 Not Found` error when accessing the API root path
-    openapi-mode = "disabled"
-
-.. _openapi-server-proxy-uri:
-
-openapi-server-proxy-uri
-------------------------
-
-  Overrides the base URL used within the OpenAPI self-documentation hosted at the API root path. Use a complete URI syntax :code:`scheme:[//[user:password@]host[:port]][/]path[?query][#fragment]`. Ex. :code:`https://postgrest.com`
-
-  .. code:: json
-
-    {
-      "swagger": "2.0",
-      "info": {
-        "version": "0.4.3.0",
-        "title": "PostgREST API",
-        "description": "This is a dynamic API generated by PostgREST"
-      },
-      "host": "postgrest.com:443",
-      "basePath": "/",
-      "schemes": [
-        "https"
-      ]
-    }
-
-.. _jwt-secret:
-
-jwt-secret
-----------
-
-  The secret or `JSON Web Key (JWK) (or set) <https://datatracker.ietf.org/doc/html/rfc7517>`_ used to decode JWT tokens clients provide for authentication. For security the key must be **at least 32 characters long**. If this parameter is not specified then PostgREST refuses authentication requests. Choosing a value for this parameter beginning with the at sign such as :code:`@filename` loads the secret out of an external file. This is useful for automating deployments. Note that any binary secrets must be base64 encoded. Both symmetric and asymmetric cryptography are supported. For more info see :ref:`asym_keys`.
-
-.. _jwt-aud:
-
-jwt-aud
--------
-
-  Specifies the `JWT audience claim <https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3>`_. If this claim is present in the client provided JWT then you must set this to the same value as in the JWT, otherwise verifying the JWT will fail.
-
-.. _secret-is-base64:
-
-secret-is-base64
-----------------
-
-  When this is set to :code:`true`, the value derived from :code:`jwt-secret` will be treated as a base64 encoded secret.
-
-.. _max-rows:
-
-max-rows
---------
-
-  A hard limit to the number of rows PostgREST will fetch from a view, table, or stored procedure. Limits payload size for accidental or malicious requests.
-
-.. _pre-request:
-
-pre-request
------------
-
-  A schema-qualified stored procedure name to call right after switching roles for a client request. This provides an opportunity to modify SQL variables or raise an exception to prevent the request from completing.
-
-.. _app.settings.*:
-
-app.settings.*
---------------
-
-  Arbitrary settings that can be used to pass in secret keys directly as strings, or via OS environment variables. For instance: :code:`app.settings.jwt_secret = "$(MYAPP_JWT_SECRET)"` will take :code:`MYAPP_JWT_SECRET` from the environment and make it available to postgresql functions as :code:`current_setting('app.settings.jwt_secret')`.
-
-.. _role-claim-key:
-
-role-claim-key
---------------
-
-  A JSPath DSL that specifies the location of the :code:`role` key in the JWT claims. This can be used to consume a JWT provided by a third party service like Auth0, Okta or Keycloak. Usage examples:
-
-  .. code:: bash
-
-    # {"postgrest":{"roles": ["other", "author"]}}
-    # the DSL accepts characters that are alphanumerical or one of "_$@" as keys
-    role-claim-key = ".postgrest.roles[1]"
-
-    # {"https://www.example.com/role": { "key": "author }}
-    # non-alphanumerical characters can go inside quotes(escaped in the config value)
-    role-claim-key = ".\"https://www.example.com/role\".key"
-
-.. _raw-media-types:
-
-raw-media-types
----------------
-
- This serves to extend the `Media Types <https://en.wikipedia.org/wiki/Media_type>`_ that PostgREST currently accepts through an ``Accept`` header.
-
- These media types can be requested by following the same rules as the ones defined in :ref:`binary_output`.
-
- As an example, the below config would allow you to request an **image** and a **XML** file by doing a request with ``Accept: image/png``
- or ``Accept: text/xml``, respectively.
-
- .. code:: bash
-
-   raw-media-types="image/png, text/xml"
 
 .. _env_variables_config:
 
@@ -436,14 +72,14 @@ In-Database Configuration
 By adding settings to the **authenticator** role (see :ref:`roles`), you can make the database the single source of truth for PostgREST's configuration.
 This is enabled by :ref:`db-config`.
 
-For example, you can configure :ref:`db-schema` and :ref:`jwt-secret` like this:
+For example, you can configure :ref:`db-schemas` and :ref:`jwt-secret` like this:
 
 .. code:: postgresql
 
-   ALTER ROLE authenticator IN DATABASE <your_database_name> SET pgrst.db_schema = "tenant1, tenant2, tenant3"
+   ALTER ROLE authenticator IN DATABASE <your_database_name> SET pgrst.db_schemas = "tenant1, tenant2, tenant3"
    ALTER ROLE authenticator IN DATABASE <your_database_name> SET pgrst.jwt_secret = "REALLYREALLYREALLYREALLYVERYSAFE"
 
-Note that underscores(``_``) need to be used instead of dashes(``-``) for the in-database config options.
+Note that underscores(``_``) need to be used instead of dashes(``-``) for the in-database config parameters.
 
 .. important::
 
@@ -469,3 +105,510 @@ To reload the in-database configuration from within the database, you can use a 
    NOTIFY pgrst, 'reload config'
 
 The ``"pgrst"`` notification channel is enabled by default. For configuring the channel, see :ref:`db-channel` and :ref:`db-channel-enabled`.
+
+.. _config_full_list:
+
+List of parameters
+==================
+
+======================== ======= ================= ======== ==========
+Name                     Type    Default           Required Reloadable
+======================== ======= ================= ======== ==========
+app.settings.*           String                             Y
+db-anon-role             String                    Y        Y
+db-channel               String  pgrst                      Y
+db-channel-enabled       Boolean True                       Y
+db-config                Boolean True                       Y
+db-extra-search-path     String  public                     Y
+db-max-rows              Int     ∞                          Y
+db-pool                  Int     10
+db-pool-timeout          Int     10
+db-pre-request           String                             Y
+db-prepared-statements   Boolean True                       Y
+db-schemas               String                    Y        Y
+db-tx-end                String  commit                     Y
+db-uri                   String                    Y
+db-use-legacy-gucs       Boolean True                       Y
+jwt-aud                  String                             Y
+jwt-role-claim-key       String  .role                      Y
+jwt-secret               String                             Y
+jwt-secret-is-base64     Boolean False                      Y
+log-level                String  error                      Y
+openapi-mode             String  follow-privileges          Y
+openapi-server-proxy-uri String                             Y
+raw-media-types          String                             Y
+server-host              String  !4
+server-port              Int     3000
+server-unix-socket       String
+server-unix-socket-mode  String  660
+======================== ======= ================= ======== ==========
+
+.. _app.settings.*:
+
+app.settings.*
+--------------
+
+  =============== ====================
+  **Environment** PGRST_APP_SETTINGS_*
+  **In-Database** pgrst.app_settings_*
+  =============== ====================
+
+  Arbitrary settings that can be used to pass in secret keys directly as strings, or via OS environment variables. For instance: :code:`app.settings.jwt_secret = "$(MYAPP_JWT_SECRET)"` will take :code:`MYAPP_JWT_SECRET` from the environment and make it available to postgresql functions as :code:`current_setting('app.settings.jwt_secret')`.
+
+.. _db-anon-role:
+
+db-anon-role
+------------
+
+  =============== ==================
+  **Environment** PGRST_DB_ANON_ROLE
+  **In-Database** `n/a`
+  =============== ==================
+
+  The database role to use when executing commands on behalf of unauthenticated clients. For more information, see :ref:`roles`.
+
+.. _db-channel:
+
+db-channel
+----------
+
+  =============== ================
+  **Environment** PGRST_DB_CHANNEL
+  **In-Database** `n/a`
+  =============== ================
+
+  The name of the notification channel that PostgREST uses for :ref:`schema_reloading` and configuration reloading.
+
+.. _db-channel-enabled:
+
+db-channel-enabled
+------------------
+
+  =============== ========================
+  **Environment** PGRST_DB_CHANNEL_ENABLED
+  **In-Database** `n/a`
+  =============== ========================
+
+  When this is set to :code:`true`, the notification channel specified in :ref:`db-channel` is enabled.
+
+  You should set this to ``false`` when using PostgresSQL behind an external connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <external_connection_poolers>` for more information.
+
+.. _db-config:
+
+db-config
+---------
+
+  =============== ===============
+  **Environment** PGRST_DB_CONFIG
+  **In-Database** `n/a`
+  =============== ===============
+
+   Enables the in-database configuration.
+
+.. _db-extra-search-path:
+
+db-extra-search-path
+--------------------
+
+  =============== ==========================
+  **Environment** PGRST_DB_EXTRA_SEARCH_PATH
+  **In-Database** pgrst.db_extra_search_path
+  =============== ==========================
+
+  Extra schemas to add to the `search_path <https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH>`_ of every request. These schemas tables, views and stored procedures **don't get API endpoints**, they can only be referred from the database objects inside your :ref:`db-schemas`.
+
+  This parameter was meant to make it easier to use **PostgreSQL extensions** (like PostGIS) that are outside of the :ref:`db-schemas`.
+
+  Multiple schemas can be added in a comma-separated string, e.g. ``public, extensions``.
+
+.. _db-max-rows:
+
+db-max-rows
+-----------
+
+  *For backwards compatibility, this config parameter is also available without prefix as "max-rows".*
+
+  =============== =================
+  **Environment** PGRST_DB_MAX_ROWS
+  **In-Database** pgrst.db_max_rows
+  =============== =================
+
+  A hard limit to the number of rows PostgREST will fetch from a view, table, or stored procedure. Limits payload size for accidental or malicious requests.
+
+.. _db-pool:
+
+db-pool
+-------
+
+  =============== =================
+  **Environment** PGRST_DB_POOL
+  **In-Database** `n/a`
+  =============== =================
+
+  Number of connections to keep open in PostgREST's database pool. Having enough here for the maximum expected simultaneous client connections can improve performance. Note it's pointless to set this higher than the :code:`max_connections` GUC in your database.
+
+.. _db-pool-timeout:
+
+db-pool-timeout
+---------------
+
+  =============== =================
+  **Environment** PGRST_DB_POOL_TIMEOUT
+  **In-Database** `n/a`
+  =============== =================
+
+   Time to live, in seconds, for an idle database pool connection. If the timeout is reached the connection will be closed.
+   Once a new request arrives a new connection will be started.
+
+.. _db-pre-request:
+
+db-pre-request
+--------------
+
+  *For backwards compatibility, this config parameter is also available without prefix as "pre-request".*
+
+  =============== =================
+  **Environment** PGRST_DB_PRE_REQUEST
+  **In-Database** pgrst.db_pre_request
+  =============== =================
+
+  A schema-qualified stored procedure name to call right after switching roles for a client request. This provides an opportunity to modify SQL variables or raise an exception to prevent the request from completing.
+
+.. _db-prepared-statements:
+
+db-prepared-statements
+----------------------
+
+  =============== =================
+  **Environment** PGRST_DB_PREPARED_STATEMENTS
+  **In-Database** pgrst.db_prepared_statements
+  =============== =================
+
+  Enables or disables prepared statements.
+
+  When disabled, the generated queries will be parameterized (invulnerable to SQL injection) but they will not be prepared (cached in the database session). Not using prepared statements will noticeably decrease performance, so it's recommended to always have this setting enabled.
+
+  You should only set this to ``false`` when using PostgresSQL behind an external connection pooler such as PgBouncer working in transaction pooling mode. See :ref:`this section <external_connection_poolers>` for more information.
+
+.. _db-schemas:
+
+db-schemas
+----------
+
+  *For backwards compatibility, this config parameter is also available in singular as "db-schema".*
+
+  =============== =================
+  **Environment** PGRST_DB_SCHEMAS
+  **In-Database** pgrst.db_schemas
+  =============== =================
+
+  The database schema to expose to REST clients. Tables, views and stored procedures in this schema will get API endpoints.
+
+  .. code:: bash
+
+     db-schemas = "api"
+
+  This schema gets added to the `search_path <https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH>`_ of every request.
+
+List of schemas
+~~~~~~~~~~~~~~~
+
+  You can also specify a list of schemas that can be used for **schema-based multitenancy** and **api versioning** by :ref:`multiple-schemas`. Example:
+
+  .. code:: bash
+
+     db-schemas = "tenant1, tenant2"
+
+  If you don't :ref:`Switch Schemas <multiple-schemas>`, the first schema in the list(``tenant1`` in this case) is chosen as the default schema.
+
+  *Only the chosen schema* gets added to the `search_path <https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH>`_ of every request.
+
+  .. warning::
+
+     Never expose private schemas in this way. See :ref:`schema_isolation`.
+
+.. _db-tx-end:
+
+db-tx-end
+---------
+
+  =============== =================
+  **Environment** PGRST_DB_TX_END
+  **In-Database** pgrst.db_tx_end
+  =============== =================
+
+  Specifies how to terminate the database transactions.
+
+  .. code:: bash
+
+    # The transaction is always committed
+    db-tx-end = "commit"
+
+    # The transaction is committed unless a "Prefer: tx=rollback" header is sent
+    db-tx-end = "commit-allow-override"
+
+    # The transaction is always rolled back
+    db-tx-end = "rollback"
+
+    # The transaction is rolled back unless a "Prefer: tx=commit" header is sent
+    db-tx-end = "rollback-allow-override"
+
+.. _db-uri:
+
+db-uri
+------
+
+  =============== =================
+  **Environment** PGRST_DB_URI
+  **In-Database** `n/a`
+  =============== =================
+
+  The standard connection PostgreSQL `URI format <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING>`_. Symbols and unusual characters in the password or other fields should be percent encoded to avoid a parse error. If enforcing an SSL connection to the database is required you can use `sslmode <https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS>`_ in the URI, for example ``postgres://user:pass@host:5432/dbname?sslmode=require``.
+
+  When running PostgREST on the same machine as PostgreSQL, it is also possible to connect to the database using a `Unix socket <https://en.wikipedia.org/wiki/Unix_domain_socket>`_ and the `Peer Authentication method <https://www.postgresql.org/docs/current/auth-peer.html>`_ as an alternative to TCP/IP communication and authentication with a password, this also grants higher performance.  To do this you can omit the host and the password, e.g. ``postgres://user@/dbname``, see the `libpq connection string <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING>`_ documentation for more details.
+
+  On older systems like Centos 6, with older versions of libpq, a different db-uri syntax has to be used. In this case the URI is a string of space separated key-value pairs (key=value), so the example above would be :code:`"host=host user=user port=5432 dbname=dbname password=pass"`.
+
+  Choosing a value for this parameter beginning with the at sign such as ``@filename`` (e.g. ``@./configs/my-config``) loads the secret out of an external file.
+
+.. _db-use-legacy-gucs:
+
+db-use-legacy-gucs
+------------------
+
+  =============== =================
+  **Environment** PGRST_DB_USE_LEGACY_GUCS
+  **In-Database** pgrst.db_use_legacy_gucs
+  =============== =================
+
+  Determine if GUC request settings for headers, cookies and jwt claims use the `legacy names <https://postgrest.org/en/v8.0/api.html#accessing-request-headers-cookies-and-jwt-claims>`_ (string with dashes, invalid starting from PostgreSQL v14) with text values instead of the :ref:`new names <guc_req_headers_cookies_claims>` (string without dashes, valid on all PostgreSQL versions) with json values.
+
+  On PostgreSQL versions 14 and above, this parameter is ignored.
+
+.. _jwt-aud:
+
+jwt-aud
+-------
+
+  =============== =================
+  **Environment** PGRST_JWT_AUD
+  **In-Database** pgrst.jwt_aud
+  =============== =================
+
+  Specifies the `JWT audience claim <https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3>`_. If this claim is present in the client provided JWT then you must set this to the same value as in the JWT, otherwise verifying the JWT will fail.
+
+.. _jwt-role-claim-key:
+
+jwt-role-claim-key
+------------------
+
+  *For backwards compatibility, this config parameter is also available without prefix as "role-claim-key".*
+
+  =============== =================
+  **Environment** PGRST_JWT_ROLE_CLAIM_KEY
+  **In-Database** pgrst.jwt_role_claim_key
+  =============== =================
+
+  A JSPath DSL that specifies the location of the :code:`role` key in the JWT claims. This can be used to consume a JWT provided by a third party service like Auth0, Okta or Keycloak. Usage examples:
+
+  .. code:: bash
+
+    # {"postgrest":{"roles": ["other", "author"]}}
+    # the DSL accepts characters that are alphanumerical or one of "_$@" as keys
+    jwt-role-claim-key = ".postgrest.roles[1]"
+
+    # {"https://www.example.com/role": { "key": "author }}
+    # non-alphanumerical characters can go inside quotes(escaped in the config value)
+    jwt-role-claim-key = ".\"https://www.example.com/role\".key"
+
+.. _jwt-secret:
+
+jwt-secret
+----------
+
+  =============== =================
+  **Environment** PGRST_JWT_SECRET
+  **In-Database** pgrst.jwt_secret
+  =============== =================
+
+  The secret or `JSON Web Key (JWK) (or set) <https://datatracker.ietf.org/doc/html/rfc7517>`_ used to decode JWT tokens clients provide for authentication. For security the key must be **at least 32 characters long**. If this parameter is not specified then PostgREST refuses authentication requests. Choosing a value for this parameter beginning with the at sign such as :code:`@filename` loads the secret out of an external file. This is useful for automating deployments. Note that any binary secrets must be base64 encoded. Both symmetric and asymmetric cryptography are supported. For more info see :ref:`asym_keys`.
+
+.. _jwt-secret-is-base64:
+
+jwt-secret-is-base64
+--------------------
+
+  =============== =================
+  **Environment** PGRST_JWT_SECRET_IS_BASE64
+  **In-Database** pgrst.jwt_secret_is_base64
+  =============== =================
+
+  When this is set to :code:`true`, the value derived from :code:`jwt-secret` will be treated as a base64 encoded secret.
+
+.. _log-level:
+
+log-level
+---------
+
+  =============== =================
+  **Environment** PGRST_LOG_LEVEL
+  **In-Database** `n/a`
+  =============== =================
+
+  Specifies the level of information to be logged while running PostgREST.
+
+  .. code:: bash
+
+      # Only startup and db connection recovery messages are logged
+      log-level = "crit"
+
+      # All the "crit" level events plus server errors (status 5xx) are logged
+      log-level = "error"
+
+      # All the "error" level events plus request errors (status 4xx) are logged
+      log-level = "warn"
+
+      # All the "warn" level events plus all requests (every status code) are logged
+      log-level = "info"
+
+
+  Because currently there's no buffering for logging, the levels with minimal logging(``crit/error``) will increase throughput.
+
+.. _openapi-mode:
+
+openapi-mode
+------------
+
+  =============== =================
+  **Environment** PGRST_OPENAPI_MODE
+  **In-Database** pgrst.openapi_mode
+  =============== =================
+
+  Specifies how the OpenAPI output should be displayed.
+
+  .. code:: bash
+
+    # Follows the privileges of the JWT role claim (or from db-anon-role if the JWT is not sent)
+    # Shows information depending on the permissions that the role making the request has
+    openapi-mode = "follow-privileges"
+
+    # Ignores the privileges of the JWT role claim (or from db-anon-role if the JWT is not sent)
+    # Shows all the exposed information, regardless of the permissions that the role making the request has
+    openapi-mode = "ignore-privileges"
+
+    # Disables the OpenApi output altogether.
+    # Throws a `404 Not Found` error when accessing the API root path
+    openapi-mode = "disabled"
+
+.. _openapi-server-proxy-uri:
+
+openapi-server-proxy-uri
+------------------------
+
+  =============== =================
+  **Environment** PGRST_OPENAPI_SERVER_PROXY_URI
+  **In-Database** pgrst.openapi_server_proxy_uri
+  =============== =================
+
+  Overrides the base URL used within the OpenAPI self-documentation hosted at the API root path. Use a complete URI syntax :code:`scheme:[//[user:password@]host[:port]][/]path[?query][#fragment]`. Ex. :code:`https://postgrest.com`
+
+  .. code:: json
+
+    {
+      "swagger": "2.0",
+      "info": {
+        "version": "0.4.3.0",
+        "title": "PostgREST API",
+        "description": "This is a dynamic API generated by PostgREST"
+      },
+      "host": "postgrest.com:443",
+      "basePath": "/",
+      "schemes": [
+        "https"
+      ]
+    }
+
+.. _raw-media-types:
+
+raw-media-types
+---------------
+
+  =============== =================
+  **Environment** PGRST_RAW_MEDIA_TYPES
+  **In-Database** pgrst.raw_media_types
+  =============== =================
+
+ This serves to extend the `Media Types <https://en.wikipedia.org/wiki/Media_type>`_ that PostgREST currently accepts through an ``Accept`` header.
+
+ These media types can be requested by following the same rules as the ones defined in :ref:`binary_output`.
+
+ As an example, the below config would allow you to request an **image** and a **XML** file by doing a request with ``Accept: image/png``
+ or ``Accept: text/xml``, respectively.
+
+ .. code:: bash
+
+   raw-media-types="image/png, text/xml"
+
+.. _server-host:
+
+server-host
+-----------
+
+  =============== =================
+  **Environment** PGRST_SERVER_HOST
+  **In-Database** pgrst.server_host
+  =============== =================
+
+  Where to bind the PostgREST web server. In addition to the usual address options, PostgREST interprets these reserved addresses with special meanings:
+
+  * :code:`*` - any IPv4 or IPv6 hostname
+  * :code:`*4` - any IPv4 or IPv6 hostname, IPv4 preferred
+  * :code:`!4` - any IPv4 hostname
+  * :code:`*6` - any IPv4 or IPv6 hostname, IPv6 preferred
+  * :code:`!6` - any IPv6 hostname
+
+.. _server-port:
+
+server-port
+-----------
+
+  =============== =================
+  **Environment** PGRST_SERVER_PORT
+  **In-Database** pgrst.server_port
+  =============== =================
+
+  The TCP port to bind the web server.
+
+.. _server-unix-socket:
+
+server-unix-socket
+------------------
+
+  =============== =================
+  **Environment** PGRST_SERVER_UNIX_SOCKET
+  **In-Database** pgrst.server_unix_socket
+  =============== =================
+
+  `Unix domain socket <https://en.wikipedia.org/wiki/Unix_domain_socket>`_ where to bind the PostgREST web server.
+  If specified, this takes precedence over :ref:`server-port`. Example:
+
+  .. code:: bash
+
+    server-unix-socket = "/tmp/pgrst.sock"
+
+.. _server-unix-socket-mode:
+
+server-unix-socket-mode
+-----------------------
+
+  =============== =================
+  **Environment** PGRST_SERVER_UNIX_SOCKET_MODE
+  **In-Database** pgrst.server_unix_socket_mode
+  =============== =================
+
+  `Unix file mode <https://en.wikipedia.org/wiki/File_system_permissions>`_ to be set for the socket specified in :ref:`server-unix-socket`
+  Needs to be a valid octal between 600 and 777.
+
+  .. code:: bash
+
+    server-unix-socket-mode = "660"

--- a/how-tos/embedding-table-from-another-schema.rst
+++ b/how-tos/embedding-table-from-another-schema.rst
@@ -3,7 +3,7 @@ Embedding a table from another schema
 
 :author: `steve-chavez <https://github.com/steve-chavez>`_
 
-Suppose you have a **people** table in the ``public`` schema and this schema is exposed through PostgREST's :ref:`db-schema`.
+Suppose you have a **people** table in the ``public`` schema and this schema is exposed through PostgREST's :ref:`db-schemas`.
 
 .. code-block:: postgres
 

--- a/postgrest.dict
+++ b/postgrest.dict
@@ -125,6 +125,7 @@ Rechkemmer
 reconnection
 Redux
 refactor
+Reloadable
 Remo
 requester's
 RESTful

--- a/releases/v7.0.0.rst
+++ b/releases/v7.0.0.rst
@@ -10,7 +10,7 @@ You can download this release at the `PostgREST v7.0.0 release page <https://git
 Added
 -----
 
-* Support for :ref:`Switching to a schema <multiple-schemas>` defined in :ref:`db-schema`.
+* Support for :ref:`Switching to a schema <multiple-schemas>` defined in :ref:`db-schemas`.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_, `@mahmoudkassem <https://github.com/mahmoudkassem>`_
 
 * Support for :ref:`planned_count` and :ref:`estimated_count`.

--- a/tutorials/tut0.rst
+++ b/tutorials/tut0.rst
@@ -162,7 +162,7 @@ PostgREST uses a configuration file to tell it how to connect to the database. C
 .. code-block:: ini
 
   db-uri = "postgres://authenticator:mysecretpassword@localhost:5433/postgres"
-  db-schema = "api"
+  db-schemas = "api"
   db-anon-role = "web_anon"
 
 The configuration file has other :ref:`options <configuration>`, but this is all we need. 

--- a/tutorials/tut1.rst
+++ b/tutorials/tut1.rst
@@ -226,7 +226,7 @@ Next update :code:`tutorial.conf` and specify the new function:
 
   # add this line to tutorial.conf
 
-  pre-request = "auth.check_token"
+  db-pre-request = "auth.check_token"
 
 Restart PostgREST for the change to take effect. Next try making a request with our original token and then with the revoked one.
 


### PR DESCRIPTION
This is kind of a rework of the configuration page, including:
- Adding the missing `db-root-spec` config parameter
- Renaming the config parameters according to https://github.com/PostgREST/postgrest/pull/1679
- Sorting all config parameters alphabetically
- Adding names for environment variables and database settings for each parameter
- Re-organizing the whole page, so that the list of parameters is last (so that the environment and database sections come before the list, which already mentions the names for those settings)