### PR TITLE
remove dead link to v5 docs

### DIFF
--- a/releases/v5.2.0.rst
+++ b/releases/v5.2.0.rst
@@ -1,7 +1,7 @@
 v5.2.0
 ======
 
-* `Explicit qualification <https://postgrest.org/en/v5.0/api.html#explicit-qualification>`_ introduced in ``v5.0`` is no longer necessary, this section will not be included from this version onwards.  A :ref:`db-extra-search-path` configuration parameter was introduced to avoid the need to explictly qualify database objects. If you install PostgreSQL extensions on the ``public`` schema, they'll work normally from now on.
+* Explicit qualification introduced in ``v5.0`` is no longer necessary, this section will not be included from this version onwards.  A :ref:`db-extra-search-path` configuration parameter was introduced to avoid the need to explictly qualify database objects. If you install PostgreSQL extensions on the ``public`` schema, they'll work normally from now on.
 
 * Now you can filter :ref:`tabs-cols-w-spaces`.
 


### PR DESCRIPTION
This is making the linkcheck fail, currently. The link is dead, because we removed the old docs. Should be fine without.