### PR TITLE
Fix references to full documents instead of first section

### DIFF
--- a/how-tos/providing-images-for-img.rst
+++ b/how-tos/providing-images-for-img.rst
@@ -38,7 +38,7 @@ We can retrieve this image in binary format from our PostgREST API by requesting
 Unfortunately, putting the URL into the :code:`src` of an :code:`<img>` tag will not work.
 That's because browsers do not send the required header.
 
-Luckily, we can configure our :ref:`Nginx reverse proxy <admin>` to fix this problem for us.
+Luckily, we can configure our :doc:`Nginx reverse proxy <../admin>` to fix this problem for us.
 We assume that PostgREST is running on port 3000.
 We provide a new location :code:`/files/` that redirects requests to our endpoint with the :code:`Accept` header set to :code:`application/octet-stream`.
 

--- a/releases/v7.0.0.rst
+++ b/releases/v7.0.0.rst
@@ -35,7 +35,7 @@ Added
 
 * Documentation improvements
 
-  + Explanation for :ref:`Schema Structure <schema_isolation>`.
+  + Explanation for :doc:`Schema Structure <../schema_structure>`.
   + Reference for :ref:`s_proc_embed`.
   + Reference for :ref:`mutation_embed`.
   + Reference for filters on :ref:`json_columns`.

--- a/releases/v8.0.0.rst
+++ b/releases/v8.0.0.rst
@@ -60,8 +60,8 @@ Added
 
 * Documentation improvements
 
-  + Added the :ref:`schema_cache` page.
-  + Moved the :ref:`schema_reloading` reference from :ref:`admin` to :ref:`schema_cache`
+  + Added the :doc:`../schema_cache` page.
+  + Moved the :ref:`schema_reloading` reference from :doc:`../admin` to :doc:`../schema_cache`
 
 Changed
 -------

--- a/releases/v9.0.0.rst
+++ b/releases/v9.0.0.rst
@@ -74,7 +74,7 @@ Breaking changes
 
 * Dropped support for PostgreSQL 9.5 as it already reached its end-of-life according to `PostgreSQL versioning policy <https://www.postgresql.org/support/versioning/>`_.
 
-* Partitions of a `partitioned table <https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE>`_ are no longer included in the :ref:`schema_cache`. This is so errors are not generated when doing resource embedding on partitioned tables.
+* Partitions of a `partitioned table <https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE>`_ are no longer included in the :doc:`../schema_cache`. This is so errors are not generated when doing resource embedding on partitioned tables.
 
 * Dropped support for doing :ref:`hint_disamb` using dots instead of exclamation marks, e.g. doing ``select=*,projects.client_id(*)`` instead of ``select=*,projects!client_id(*)``). Using dots was undocumented and deprecated back in `v6.0.2 <https://github.com/PostgREST/postgrest/releases/tag/v6.0.2>`_.
 

--- a/tutorials/tut0.rst
+++ b/tutorials/tut0.rst
@@ -165,7 +165,7 @@ PostgREST can use a configuration file to tell it how to connect to the database
   db-schemas = "api"
   db-anon-role = "web_anon"
 
-The configuration file has other :ref:`options <configuration>`, but this is all we need. 
+The configuration file has other :doc:`options <../configuration>`, but this is all we need. 
 If you are not using Docker, make sure that your port number is correct and replace `postgres` with the name of the database where you added the todos table.
 
 Now run the server:


### PR DESCRIPTION
As noticed in #492 some references are pointing to the first section of a document, when they should instead point to the full document. This doesn't make any difference to the user afaik, but is more about consistency.