### PR TITLE
Add admin section on file descriptors

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -256,6 +256,7 @@ Schema Reloading
 
 Changing the schema while the server is running can lead to errors due to a stale schema cache. To learn how to refresh the cache see :ref:`schema_reloading`.
 
+
 Daemonizing
 ===========
 
@@ -294,6 +295,17 @@ After that, you can enable the service at boot time and start it with:
 
   ## For reloading the service
   ## systemctl restart postgrest
+
+File Descriptors
+----------------
+
+File descriptors are kernel resources that are used by http connections(among others). File descriptors are limited per process and depending on the Linux distribution, they can have a default limit value of 1024, 4096, etc.
+When under heavy traffic, PostgREST can reach this limit and start showing errors like ``No file descriptors available``. To clear these errors, you can increase the process file descriptors' limit.
+
+.. code-block:: ini
+
+  [Service]
+  LimitNOFILE=10000
 
 Alternate URL Structure
 =======================

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -299,8 +299,8 @@ After that, you can enable the service at boot time and start it with:
 File Descriptors
 ----------------
 
-File descriptors are kernel resources that are used by HTTP connections(among others). File descriptors are limited per process and depending on the Linux distribution, they can have a default limit value of 1024, 4096, etc.
-When under heavy traffic, PostgREST can reach this limit and start showing errors like ``No file descriptors available``. To clear these errors, you can increase the process file descriptors' limit.
+File descriptors are kernel resources that are used by HTTP connections (among others). File descriptors are limited per process. The kernel default limit is 1024, which is increased in some Linux distributions.
+When under heavy traffic, PostgREST can reach this limit and start showing ``No file descriptors available`` errors. To clear these errors, you can increase the process' file descriptor limit.
 
 .. code-block:: ini
 

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -299,7 +299,7 @@ After that, you can enable the service at boot time and start it with:
 File Descriptors
 ----------------
 
-File descriptors are kernel resources that are used by http connections(among others). File descriptors are limited per process and depending on the Linux distribution, they can have a default limit value of 1024, 4096, etc.
+File descriptors are kernel resources that are used by HTTP connections(among others). File descriptors are limited per process and depending on the Linux distribution, they can have a default limit value of 1024, 4096, etc.
 When under heavy traffic, PostgREST can reach this limit and start showing errors like ``No file descriptors available``. To clear these errors, you can increase the process file descriptors' limit.
 
 .. code-block:: ini

--- a/postgrest.dict
+++ b/postgrest.dict
@@ -51,6 +51,7 @@ Haskell
 Heroku
 HMAC
 Homebrew
+HTTP
 HTTPS
 HV
 Ibarluzea


### PR DESCRIPTION
Related to https://github.com/PostgREST/postgrest/pull/2158.

Timeouts can be better explained when the `/metrics` endpoint is available, so I've just scoped this PR to file descriptors.