### PR TITLE
Fix not reloading the schema cache on ALTER TYPE

### DIFF
--- a/docs/schema_cache.rst
+++ b/docs/schema_cache.rst
@@ -191,7 +191,7 @@ reloading when creating temporary tables(``CREATE TEMP TABLE``) inside functions
       , 'CREATE MATERIALIZED VIEW', 'ALTER MATERIALIZED VIEW'
       , 'CREATE FUNCTION', 'ALTER FUNCTION'
       , 'CREATE TRIGGER'
-      , 'CREATE TYPE'
+      , 'CREATE TYPE', 'ALTER TYPE'
       , 'CREATE RULE'
       , 'COMMENT'
       )


### PR DESCRIPTION
Caught in https://github.com/supabase/supabase/issues/5946.