### PR TITLE
Allow returning XML

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -587,14 +587,14 @@ raw-media-types
 
  This serves to extend the `Media Types <https://en.wikipedia.org/wiki/Media_type>`_ that PostgREST currently accepts through an ``Accept`` header.
 
- These media types can be requested by following the same rules as the ones defined in :ref:`binary_output`.
+ These media types can be requested by following the same rules as the ones defined in :ref:`scalar_return_formats`.
 
  As an example, the below config would allow you to request an **image** and a **XML** file by doing a request with ``Accept: image/png``
- or ``Accept: text/xml``, respectively.
+ or ``Accept: font/woff2``, respectively.
 
  .. code:: bash
 
-   raw-media-types="image/png, text/xml"
+   raw-media-types="image/png, font/woff2"
 
 .. _server-host:
 

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -193,8 +193,9 @@ Related to the HTTP request elements.
 |               | See :ref:`guc_resp_status`.                                 |
 | PGRST112      |                                                             |
 +---------------+-------------------------------------------------------------+
-| .. _pgrst113: | Related to :ref:`binary_output`. See :ref:`providing_img`   |
-|               | for an example on requesting images.                        |
+| .. _pgrst113: | Related to :ref:`scalar_return_formats`.                    |
+|               | See :ref:`providing_img` for an example on requesting       |
+|               | images.                                                     |
 | PGRST113      |                                                             |
 +---------------+-------------------------------------------------------------+
 | .. _pgrst114: | For an :ref:`UPSERT using PUT <upsert_put>`, when           |

--- a/docs/releases/v6.0.2.rst
+++ b/docs/releases/v6.0.2.rst
@@ -23,7 +23,7 @@ Added
 * Bulk calling an RPC is now allowed. See :ref:`bulk_call`.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
 
-* It's now possible to request a ``text/plain`` output. See :ref:`plain_text_output`.
+* It's now possible to request a ``text/plain`` output. See :ref:`scalar_return_formats`.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
 
 * Config option for specifying PostgREST database pool timeout. See :ref:`db-pool-timeout`.


### PR DESCRIPTION
cf.
- https://github.com/PostgREST/postgrest/pull/2202
- https://github.com/PostgREST/postgrest/pull/2268


#### Considerations / Suggestions
- I have not adapted https://postgrest.org/en/latest/api.html#response-format because
  - `text/plain` isn't listed there either - a mistake?
  - As far as I understand it should be made clear that `application/octet-stream`, `text/plain`, `text/xml` only work under the conditions mentioned in https://postgrest.org/en/latest/api.html#binary-output ?
- Now we have 3 paragraphs https://postgrest.org/en/latest/api.html#binary-output, https://postgrest.org/en/latest/api.html#plain-text-output, https://postgrest.org/en/latest/api.html#xml-output .
  - Both plain-text-output and xml-output just talk about "columns" not mentioning RPC return values
  - Maybe we should merge all three paragraphs, explain the concept more generally? 