### PR TITLE
Fix unordered list styles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-docutils<0.18
-sphinx-tabs
+docutils==0.16
+sphinx>=4.3.0
 sphinx-copybutton
+sphinx-rtd-theme>=0.5.1
+sphinx-tabs


### PR DESCRIPTION
Strangely, the `stable` docs still show problems with bullet lists. They should be the same as v9.0 which does not have that problem. Since rebuilding the `stable` did does not solve this, I added here the fix used for the latest version.