### PR TITLE
Add disclaimer on $ usage in jwt-secret values

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -482,7 +482,7 @@ jwt-secret
 
   .. warning::
 
-     Only when using a configuration file, if the value contains a ``$`` character by itself it will give errors. In this case, use ``$$`` and PostgREST will interpret it as a single ``$`` character.
+     Only when using the :ref:`file_config`, if the ``jwt-secret`` contains a ``$`` character by itself it will give errors. In this case, use ``$$`` and PostgREST will interpret it as a single ``$`` character.
 
 .. _jwt-secret-is-base64:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -480,6 +480,10 @@ jwt-secret
 
   Choosing a value for this parameter beginning with the at sign such as ``@filename`` (e.g. ``@./configs/my-config``) loads the secret out of an external file.
 
+  .. warning::
+
+     Only when using a configuration file, if the value contains a ``$`` character by itself it will give errors. In this case, use ``$$`` and PostgREST will interpret it as a single ``$`` character.
+
 .. _jwt-secret-is-base64:
 
 jwt-secret-is-base64


### PR DESCRIPTION
Using the symbol `$` fails when using it in values of the configuration file (not when using environment variables). Needs `$$` in order to interpret it as a single `$`. This is due to these lines in the configuration parser: https://github.com/robx/configurator-pg/blob/master/src/Data/Configurator/Syntax.hs#L137-L138.
