### PR TITLE
RPC POST for function w/single unnamed XML param, postgrest-PR #2300

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2043,7 +2043,7 @@ You can also call a function that takes a single parameter of type JSON by sendi
 Calling functions with a single unnamed parameter
 -------------------------------------------------
 
-You can make a POST request to a function with a single unnamed parameter to send raw ``json/jsonb``, ``bytea`` or ``text`` data.
+You can make a POST request to a function with a single unnamed parameter to send raw ``json/jsonb``, ``bytea``, ``text`` or ``xml`` data.
 
 To send raw JSON, the function must have a single unnamed ``json`` or ``jsonb`` parameter and the header ``Content-Type: application/json`` must be included in the request.
 
@@ -2075,6 +2075,8 @@ To send raw JSON, the function must have a single unnamed ``json`` or ``jsonb`` 
 .. note::
 
   If an overloaded function has a single ``json`` or ``jsonb`` unnamed parameter, PostgREST will call this function as a fallback provided that no other overloaded function is found with the parameters sent in the POST request.
+
+To send raw XML, the parameter type must be ``xml`` and the header ``Content-Type: text/xml`` must be included in the request.
 
 To send raw binary, the parameter type must be ``bytea`` and the header ``Content-Type: application/octet-stream`` must be included in the request.
 


### PR DESCRIPTION
documentation concerning https://github.com/PostgREST/postgrest/pull/2300