### PR TITLE
Add HTTP status codes to PGRST errors

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -125,21 +125,21 @@ Group 0 - Connection
 
 Related to the connection with the database.
 
-+---------------+-------------------------------------------------------------+
-| Code          | Description                                                 |
-+===============+=============================================================+
-| .. _pgrst000: | Could not connect with the database due to an incorrect     |
-|               | :ref:`db-uri` or due to the PostgreSQL service not running. |
-| PGRST000      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst001: | Could not connect with the database due to an internal      |
-|               | error.                                                      |
-| PGRST001      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst002: | Could not connect with the database when building the       |
-|               | :ref:`schema_cache` due to the PostgreSQL service not       |
-| PGRST002      | running.                                                    |
-+---------------+-------------------------------------------------------------+
++---------------+-------------+-------------------------------------------------------------+
+| Code          | HTTP status | Description                                                 |
++===============+=============+=============================================================+
+| .. _pgrst000: | 503, 504    | Could not connect with the database due to an incorrect     |
+|               |             | :ref:`db-uri` or due to the PostgreSQL service not running. |
+| PGRST000      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst001: | 503         | Could not connect with the database due to an internal      |
+|               |             | error.                                                      |
+| PGRST001      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst002: | 503         | Could not connect with the database when building the       |
+|               |             | :ref:`schema_cache` due to the PostgreSQL service not       |
+| PGRST002      |             | running.                                                    |
++---------------+-------------+-------------------------------------------------------------+
 
 .. _pgrst1**:
 
@@ -148,82 +148,81 @@ Group 1 - Api Request
 
 Related to the HTTP request elements.
 
-+---------------+-------------------------------------------------------------+
-| Code          | Description                                                 |
-+===============+=============================================================+
-| .. _pgrst100: | Parsing error in the query string parameter.                |
-|               | See :ref:`h_filter`, :ref:`operators` and :ref:`ordering`.  |
-| PGRST100      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst101: | For :ref:`functions <s_procs>`, only ``GET`` and ``POST``   |
-|               | verbs are allowed. Any other verb will throw this error.    |
-| PGRST101      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst102: | An invalid request body was sent(e.g. an empty body or      |
-|               | malformed JSON).                                            |
-| PGRST102      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst103: | An invalid range was specified for :ref:`limits`.           |
-|               |                                                             |
-| PGRST103      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst104: | Either the :ref:`filter operator <operators>` is missing    |
-|               | or it doesn't exist.                                        |
-| PGRST104      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst105: | An invalid :ref:`PUT <upsert_put>` request was done         |
-|               |                                                             |
-| PGRST105      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst106: | The schema specified when                                   |
-|               | :ref:`switching schemas <multiple-schemas>` is not present  |
-| PGRST106      | in the :ref:`db-schemas` configuration variable.            |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst107: | The ``Content-Type`` sent in the request is invalid.        |
-|               |                                                             |
-| PGRST107      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst108: | The filter is applied to a embedded resource that is not    |
-|               | specified in the ``select`` part of the query string.       |
-| PGRST108      | See :ref:`embed_filters`.                                   |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst109: | Restricting a Deletion or an Update using limits must       |
-|               | include the ordering of a unique column.                    |
-| PGRST109      | See :ref:`limited_update_delete`.                           |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst110: | When restricting a Deletion or an Update using limits       |
-|               | modifies more rows than the maximum specified in the limit. |
-| PGRST110      | See :ref:`limited_update_delete`.                           |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst111: | An invalid ``response.headers`` was set.                    |
-|               | See :ref:`guc_resp_hdrs`.                                   |
-| PGRST111      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst112: | The status code must be a positive integer.                 |
-|               | See :ref:`guc_resp_status`.                                 |
-| PGRST112      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst113: | More than one column was returned for a scalar result.      |
-|               | See :ref:`scalar_return_formats`.                           |
-|               |                                                             |
-| PGRST113      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst114: | For an :ref:`UPSERT using PUT <upsert_put>`, when           |
-|               | :ref:`limits and offsets <limits>` are used.                |
-| PGRST114      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst115: | For an :ref:`UPSERT using PUT <upsert_put>`, when the       |
-|               | primary key in the query string and the body are different. |
-| PGRST115      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst116: | More than 1 or no items where returned when requesting      |
-|               | a singular response. See :ref:`singular_plural`.            |
-| PGRST116      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst117: | The HTTP verb used in the request in not supported.         |
-|               |                                                             |
-| PGRST117      |                                                             |
-+---------------+-------------------------------------------------------------+
++---------------+-------------+-------------------------------------------------------------+
+| Code          | HTTP status | Description                                                 |
++===============+=============+=============================================================+
+| .. _pgrst100: | 400         | Parsing error in the query string parameter.                |
+|               |             | See :ref:`h_filter`, :ref:`operators` and :ref:`ordering`.  |
+| PGRST100      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst101: | 405         | For :ref:`functions <s_procs>`, only ``GET`` and ``POST``   |
+|               |             | verbs are allowed. Any other verb will throw this error.    |
+| PGRST101      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst102: | 400         | An invalid request body was sent(e.g. an empty body or      |
+|               |             | malformed JSON).                                            |
+| PGRST102      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst103: | 416         | An invalid range was specified for :ref:`limits`.           |
+|               |             |                                                             |
+| PGRST103      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst104: | 400         | Either the :ref:`filter operator <operators>` is missing    |
+|               |             | or it doesn't exist.                                        |
+| PGRST104      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst105: | 405         | An invalid :ref:`PUT <upsert_put>` request was done         |
+|               |             |                                                             |
+| PGRST105      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst106: |  406        | The schema specified when                                   |
+|               |             | :ref:`switching schemas <multiple-schemas>` is not present  |
+| PGRST106      |             | in the :ref:`db-schemas` configuration variable.            |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst107: |  415        | The ``Content-Type`` sent in the request is invalid.        |
+|               |             |                                                             |
+| PGRST107      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst108: | 400         | The filter is applied to a embedded resource that is not    |
+|               |             | specified in the ``select`` part of the query string.       |
+| PGRST108      |             | See :ref:`embed_filters`.                                   |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst109: | 400         | Restricting a Deletion or an Update using limits must       |
+|               |             | include the ordering of a unique column.                    |
+| PGRST109      |             | See :ref:`limited_update_delete`.                           |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst110: | 400         | When restricting a Deletion or an Update using limits       |
+|               |             | modifies more rows than the maximum specified in the limit. |
+| PGRST110      |             | See :ref:`limited_update_delete`.                           |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst111: | 500         | An invalid ``response.headers`` was set.                    |
+|               |             | See :ref:`guc_resp_hdrs`.                                   |
+| PGRST111      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst112: | 500         | The status code must be a positive integer.                 |
+|               |             | See :ref:`guc_resp_status`.                                 |
+| PGRST112      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst113: | 406         | More than one column was returned for a scalar result.      |
+|               |             | See :ref:`scalar_return_formats`.                           |
+| PGRST113      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst114: | 400         | For an :ref:`UPSERT using PUT <upsert_put>`, when           |
+|               |             | :ref:`limits and offsets <limits>` are used.                |
+| PGRST114      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst115: | 400         | For an :ref:`UPSERT using PUT <upsert_put>`, when the       |
+|               |             | primary key in the query string and the body are different. |
+| PGRST115      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst116: | 406         | More than 1 or no items where returned when requesting      |
+|               |             | a singular response. See :ref:`singular_plural`.            |
+| PGRST116      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst117: | 405         | The HTTP verb used in the request in not supported.         |
+|               |             |                                                             |
+| PGRST117      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
 
 .. _pgrst2**:
 
@@ -232,27 +231,27 @@ Group 2 - Schema Cache
 
 Related to a :ref:`stale schema cache <stale_schema>`. Most of the time, these errors are solved by :ref:`reloading the schema cache <schema_reloading>`.
 
-+---------------+-------------------------------------------------------------+
-| Code          | Description                                                 |
-+===============+=============================================================+
-| .. _pgrst200: | Caused by :ref:`stale_fk_relationships`, otherwise any of   |
-|               | the embedding resources or the relationship itself may not  |
-| PGRST200      | exist in the database.                                      |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst201: | An ambiguous embedding request was made.                    |
-|               | See :ref:`embed_disamb`.                                    |
-| PGRST201      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst202: | Caused by a :ref:`stale_function_signature`, otherwise      |
-|               | the function may not exist in the database.                 |
-| PGRST202      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst203: | Caused by requesting overloaded functions with the same     |
-|               | argument names but different types, or by using a ``POST``  |
-| PGRST203      | verb to request overloaded functions with a ``JSON`` or     |
-|               | ``JSONB`` type unnamed parameter. The solution is to rename |
-|               | the function or add/modify the names of the arguments.      |
-+---------------+-------------------------------------------------------------+
++---------------+-------------+-------------------------------------------------------------+
+| Code          | HTTP status | Description                                                 |
++===============+=============+=============================================================+
+| .. _pgrst200: | 400         | Caused by :ref:`stale_fk_relationships`, otherwise any of   |
+|               |             | the embedding resources or the relationship itself may not  |
+| PGRST200      |             | exist in the database.                                      |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst201: | 300         | An ambiguous embedding request was made.                    |
+|               |             | See :ref:`embed_disamb`.                                    |
+| PGRST201      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst202: | 404         | Caused by a :ref:`stale_function_signature`, otherwise      |
+|               |             | the function may not exist in the database.                 |
+| PGRST202      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst203: | 300         | Caused by requesting overloaded functions with the same     |
+|               |             | argument names but different types, or by using a ``POST``  |
+| PGRST203      |             | verb to request overloaded functions with a ``JSON`` or     |
+|               |             | ``JSONB`` type unnamed parameter. The solution is to rename |
+|               |             | the function or add/modify the names of the arguments.      |
++---------------+-------------+-------------------------------------------------------------+
 
 .. _pgrst3**:
 
@@ -261,21 +260,21 @@ Group 3 - JWT
 
 Related to the authentication process using JWT. You can follow the :ref:`tut1` for an example on how to implement authentication and the :doc:`Authentication page <auth>` for more information on this process.
 
-+---------------+-------------------------------------------------------------+
-| Code          | Description                                                 |
-+===============+=============================================================+
-| .. _pgrst300: | A :ref:`JWT secret <jwt-secret>` is missing from the        |
-|               | configuration.                                              |
-| PGRST300      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst301: | Any error related to the verification of the JWT,           |
-|               | which means that the JWT provided is invalid in some way.   |
-| PGRST301      |                                                             |
-+---------------+-------------------------------------------------------------+
-| .. _pgrst302: | Attempted to do a request without                           |
-|               | :ref:`authentication <client_auth>` when the anonymous role |
-| PGRST302      | is disabled by not setting it in :ref:`db-anon-role`.       |
-+---------------+-------------------------------------------------------------+
++---------------+-------------+-------------------------------------------------------------+
+| Code          | HTTP status | Description                                                 |
++===============+=============+=============================================================+
+| .. _pgrst300: | 500         | A :ref:`JWT secret <jwt-secret>` is missing from the        |
+|               |             | configuration.                                              |
+| PGRST300      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst301: | 401         | Any error related to the verification of the JWT,           |
+|               |             | which means that the JWT provided is invalid in some way.   |
+| PGRST301      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst302: | 401         | Attempted to do a request without                           |
+|               |             | :ref:`authentication <client_auth>` when the anonymous role |
+| PGRST302      |             | is disabled by not setting it in :ref:`db-anon-role`.       |
++---------------+-------------+-------------------------------------------------------------+
 
 .. The Internal Errors Group X** is always at the end
 
@@ -286,10 +285,10 @@ Group X - Internal
 
 Internal errors. If you encounter any of these, you may have stumbled on a PostgREST bug, please `open an issue <https://github.com/PostgREST/postgrest/issues>`_ and we'll be glad to fix it.
 
-+---------------+-------------------------------------------------------------+
-| Code          | Description                                                 |
-+===============+=============================================================+
-| .. _pgrstX00: | Internal errors related to the library used for connecting  |
-|               | to the database.                                            |
-| PGRSTX00      |                                                             |
-+---------------+-------------------------------------------------------------+
++---------------+-------------+-------------------------------------------------------------+
+| Code          | HTTP status | Description                                                 |
++===============+=============+=============================================================+
+| .. _pgrstX00: | 500         | Internal errors related to the library used for connecting  |
+|               |             | to the database.                                            |
+| PGRSTX00      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -128,7 +128,7 @@ Related to the connection with the database.
 +---------------+-------------+-------------------------------------------------------------+
 | Code          | HTTP status | Description                                                 |
 +===============+=============+=============================================================+
-| .. _pgrst000: | 503, 504    | Could not connect with the database due to an incorrect     |
+| .. _pgrst000: | 503         | Could not connect with the database due to an incorrect     |
 |               |             | :ref:`db-uri` or due to the PostgreSQL service not running. |
 | PGRST000      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
@@ -139,6 +139,10 @@ Related to the connection with the database.
 | .. _pgrst002: | 503         | Could not connect with the database when building the       |
 |               |             | :ref:`schema_cache` due to the PostgreSQL service not       |
 | PGRST002      |             | running.                                                    |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst003: | 503         | The request time exceeded the timeout specified in          |
+|               |             | :ref:`db-pool-acquisition-timeout`.                         |
+| PGRST003      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
 
 .. _pgrst1**:
@@ -171,11 +175,11 @@ Related to the HTTP request elements.
 |               |             |                                                             |
 | PGRST105      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
-| .. _pgrst106: |  406        | The schema specified when                                   |
+| .. _pgrst106: | 406         | The schema specified when                                   |
 |               |             | :ref:`switching schemas <multiple-schemas>` is not present  |
 | PGRST106      |             | in the :ref:`db-schemas` configuration variable.            |
 +---------------+-------------+-------------------------------------------------------------+
-| .. _pgrst107: |  415        | The ``Content-Type`` sent in the request is invalid.        |
+| .. _pgrst107: | 415         | The ``Content-Type`` sent in the request is invalid.        |
 |               |             |                                                             |
 | PGRST107      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
@@ -259,6 +263,10 @@ Related to a :ref:`stale schema cache <stale_schema>`. Most of the time, these e
 | PGRST203      |             | verb to request overloaded functions with a ``JSON`` or     |
 |               |             | ``JSONB`` type unnamed parameter. The solution is to rename |
 |               |             | the function or add/modify the names of the arguments.      |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst204: | 400         | Caused when the :ref:`column specified <specify_columns>`   |
+|               |             | in the ``columns`` query parameter is not found.            |
+| PGRST204      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
 
 .. _pgrst3**:

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -167,10 +167,6 @@ Related to the HTTP request elements.
 |               |             |                                                             |
 | PGRST103      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
-| .. _pgrst104: | 400         | Either the :ref:`filter operator <operators>` is missing    |
-|               |             | or it doesn't exist.                                        |
-| PGRST104      |             |                                                             |
-+---------------+-------------+-------------------------------------------------------------+
 | .. _pgrst105: | 405         | An invalid :ref:`PUT <upsert_put>` request was done         |
 |               |             |                                                             |
 | PGRST105      |             |                                                             |
@@ -222,6 +218,18 @@ Related to the HTTP request elements.
 | .. _pgrst117: | 405         | The HTTP verb used in the request in not supported.         |
 |               |             |                                                             |
 | PGRST117      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst118: | 400         | Could not order the result using the related table because  |
+|               |             | there is no many-to-one or one-to-one relationship between  |
+| PGRST118      |             | them.                                                       |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst119: | 400         | Could not use the spread operator on the related table      |
+|               |             | because there is no many-to-one or one-to-one relationship  |
+| PGRST119      |             | between them.                                               |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst120: | 400         | An embedded resource can only be filtered using the         |
+|               |             | ``is.null`` or ``not.is.null`` :ref:`operators <operators>`.|
+| PGRST120      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
 
 .. _pgrst2**:

--- a/postgrest.dict
+++ b/postgrest.dict
@@ -126,7 +126,6 @@ PostgreSQL
 PostgreSQL's
 PostgREST
 postgres
-postgres's
 postgrest
 PostgREST's
 pre


### PR DESCRIPTION
Adds HTTP status codes to the PGRST errors. Also removes deprecated errors and adds missing ones.