### PR TITLE
Add Transactions reference

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,3 +4,7 @@ sphinx:
 python:
    install:
    - requirements: requirements.txt
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -368,7 +368,7 @@ db-pre-request
   **In-Database** pgrst.db_pre_request
   =============== =================
 
-  A schema-qualified stored procedure name to call right after switching roles for a client request. This provides an opportunity to modify SQL variables or raise an exception to prevent the request from completing.
+  A schema-qualified stored procedure name to call right after the :ref:`tx_settings` are set. See :ref:`pre-request`.
 
 .. _db-prepared-statements:
 

--- a/docs/db_authz.rst
+++ b/docs/db_authz.rst
@@ -57,20 +57,19 @@ Alternately database roles can represent groups instead of (or in addition to) i
     "email": "john@doe.com"
   }
 
-SQL code can access claims through GUC variables set by PostgREST per request. For instance to get the email claim, call this function:
-
-For PostgreSQL server version >= 14
+SQL code can access claims through PostgREST :ref:`tx_settings`. For instance to get the email claim, call this function:
 
 .. code:: sql
 
   current_setting('request.jwt.claims', true)::json->>'email';
 
+.. note::
 
-For PostgreSQL server version < 14
+  For PostgreSQL < 14
 
-.. code:: sql
+  .. code:: sql
 
-  current_setting('request.jwt.claim.email', true);
+    current_setting('request.jwt.claim.email', true);
 
 This allows JWT generation services to include extra information and your database code to react to it. For instance the RLS example could be modified to use this ``current_setting`` rather than ``current_user``. The second ``'true'`` argument tells ``current_setting`` to return NULL if the setting is missing from the current configuration.
 

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -1,9 +1,14 @@
 .. _error_source:
 
-Error Source
+Error Format
 ============
 
-For the most part, error messages will come directly from the database with the same `structure that PostgreSQL uses <https://www.postgresql.org/docs/current/error-style-guide.html>`_. PostgREST will convert the ``MESSAGE``, ``DETAIL``, ``HINT`` and ``ERRCODE`` from the PostgreSQL error to JSON and add an HTTP status code to the response. For instance, when querying a nonexistent table:
+PostgREST error messages follow the PostgreSQL error structure. It includes ``MESSAGE``, ``DETAIL``, ``HINT``, ``ERRCODE`` and will add an HTTP status code to the response.
+
+Errors from PostgreSQL
+----------------------
+
+PostgREST will forward errors coming from PostgreSQL. For instance, when querying a nonexistent table:
 
 .. code-block:: http
 
@@ -23,7 +28,10 @@ For the most part, error messages will come directly from the database with the 
     "message": "relation \"api.nonexistent_table\" does not exist"
   }
 
-However, some errors do come from PostgREST itself (such as those related to the :doc:`Schema Cache <schema_cache>`). These have the same structure as the PostgreSQL errors but are differentiated by the ``PGRST`` prefix in the ``code`` field. For instance, when querying a function that does not exist:
+Errors from PostgREST
+---------------------
+
+Errors that come from PostgREST itself maintain the same structure. But differ in the ``PGRST`` prefix in the ``code`` field. For instance, when querying a function that does not exist in the :doc:`schema cache <schema_cache>`:
 
 .. code-block:: http
 
@@ -37,7 +45,7 @@ However, some errors do come from PostgREST itself (such as those related to the
 .. code-block:: json
 
   {
-    "hint": "If a new function was created in the database with this name and parameters, try reloading the schema cache.",
+    "hint": "...",
     "details": null
     "code": "PGRST202",
     "message": "Could not find the api.nonexistent_function() function in the schema cache"
@@ -250,7 +258,7 @@ Related to a :ref:`stale schema cache <stale_schema>`. Most of the time, these e
 +---------------+-------------+-------------------------------------------------------------+
 | Code          | HTTP status | Description                                                 |
 +===============+=============+=============================================================+
-| .. _pgrst200: | 400         | Caused by :ref:`stale_fk_relationships`, otherwise any of   |
+| .. _pgrst200: | 400         | Caused by stale foreign key relationships, otherwise any of |
 |               |             | the embedding resources or the relationship itself may not  |
 | PGRST200      |             | exist in the database.                                      |
 +---------------+-------------+-------------------------------------------------------------+
@@ -258,7 +266,7 @@ Related to a :ref:`stale schema cache <stale_schema>`. Most of the time, these e
 |               |             | See :ref:`embed_disamb`.                                    |
 | PGRST201      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
-| .. _pgrst202: | 404         | Caused by a :ref:`stale_function_signature`, otherwise      |
+| .. _pgrst202: | 404         | Caused by a stale function signature, otherwise             |
 |               |             | the function may not exist in the database.                 |
 | PGRST202      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -125,8 +125,8 @@ Are you new to PostgREST? This is the place to start!
 
 Also have a look at :doc:`Installation <install>` and :ref:`community_tutorials`.
 
-Reference guides
-----------------
+References
+----------
 
 Technical references for PostgREST's functionality.
 
@@ -141,6 +141,12 @@ Technical references for PostgREST's functionality.
    :hidden:
 
    api.rst
+
+.. toctree::
+   :caption: Transactions
+   :hidden:
+
+   transactions.rst
 
 .. toctree::
    :caption: Configuration
@@ -162,14 +168,15 @@ Technical references for PostgREST's functionality.
 
 - :doc:`Authentication <auth>`
 - :doc:`API <api>`
+- :doc:`Transactions <transactions>`
 - :doc:`configuration`
 - :doc:`Schema Cache <schema_cache>`
 - :doc:`Errors <errors>`
 
-Topic guides
+Explanations
 ------------
 
-Explanations of some key concepts in PostgREST.
+Key concepts in PostgREST.
 
 .. toctree::
    :caption: Database Authorization
@@ -198,7 +205,7 @@ Explanations of some key concepts in PostgREST.
 How-to guides
 -------------
 
-These are recipes that'll help you address specific use-cases.
+Recipes that'll help you address specific use-cases.
 
 .. toctree::
    :glob:

--- a/docs/releases/v8.0.0.rst
+++ b/docs/releases/v8.0.0.rst
@@ -84,11 +84,11 @@ Changed
 * Modified the default logging level from ``info`` to ``error``. See :ref:`log-level`.
   |br| -- `@steve-chavez <https://github.com/steve-chavez>`_
 
-* Changed the error message for a not found RPC on a stale schema (see :ref:`stale_function_signature`) and for the unsupported case of
+* Changed the error message for a not found RPC on a stale schema (see :ref:`stale_schema`) and for the unsupported case of
   overloaded functions with the same argument names but different types.
   |br| -- `@laurenceisla <https://github.com/laurenceisla>`_
 
-* Changed the error message for the no relationship found error. See :ref:`stale_fk_relationships`.
+* Changed the error message for the no relationship found error. See :ref:`stale_schema`.
   |br| -- `@laurenceisla <https://github.com/laurenceisla>`_
 
 Fixed

--- a/docs/releases/v9.0.0.rst
+++ b/docs/releases/v9.0.0.rst
@@ -12,7 +12,7 @@ PostgreSQL 14 compatibility
 
 PostgreSQL 14 Beta 1 tightened its GUC naming scheme making it impossible to use multiple dots (``.``) and dashes (``-``) on custom GUC parameters, this caused our `old HTTP Context <https://postgrest.org/en/v8.0/api.html#accessing-request-headers-cookies-and-jwt-claims>`_ to fail across all requests. Thankfully, `@robertsosinski <https://github.com/robertsosinski>`_ got the PostgreSQL team to reconsider allowing multiple dots in the GUC name, allowing us to avoid a major breaking change. You can see the full discussion `here <https://www.postgresql.org/message-id/17045-6a4a9f0d1513f72b%40postgresql.org>`_.
 
-Still, dashes cannot be used on PostgreSQL 14 custom GUC parameters, so we changed our HTTP Context :ref:`to namespace using a mix of dots and JSON <guc_req_headers_cookies_claims>`. On older PostgreSQL versions we still use the :ref:`guc_legacy_names`. If you wish to use the new JSON GUCs on these versions, set the :ref:`db-use-legacy-gucs` config option to false.
+Still, dashes cannot be used on PostgreSQL 14 custom GUC parameters, so we changed our HTTP Context :ref:`to namespace using a mix of dots and JSON <guc_req_headers_cookies_claims>`. On older PostgreSQL versions we still use the settings legacy names. If you wish to use the new JSON GUCs on these versions, set the :ref:`db-use-legacy-gucs` config option to false.
 
 Resource Embedding with Top-level Filtering
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/schema_cache.rst
+++ b/docs/schema_cache.rst
@@ -4,8 +4,7 @@
 
   <h1>Schema Cache</h1>
 
-Certain PostgREST features require metadata from the database schema. Getting this metadata requires executing expensive queries, so
-in order to avoid repeating this work, PostgREST uses a schema cache.
+Some PostgREST features need metadata from the database schema. Getting this metadata requires expensive queries. To avoid repeating this work, PostgREST uses a schema cache.
 
 +--------------------------------------------+-------------------------------------------------------------------------------+
 | Feature                                    | Required Metadata                                                             |
@@ -30,84 +29,19 @@ in order to avoid repeating this work, PostgREST uses a schema cache.
 
 .. _stale_schema:
 
-The Stale Schema Cache
-----------------------
+Stale Schema Cache
+------------------
 
-When you make changes on the metadata mentioned above, the schema cache will turn stale on a running PostgREST. Future requests that use the above features will need the :ref:`schema cache to be reloaded <schema_reloading>`; otherwise, you'll get an error instead of the expected result.
+One operational problem that comes a cache is that it can go stale. This can happen for PostgREST when you make changes to the metadata before mentioned. Requests that depend on the metadata will fail.
 
-For instance, let's see what would happen if you have a stale schema cache for foreign key relationships and function signatures.
-
-.. _stale_fk_relationships:
-
-Stale Foreign Key Relationships
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Suppose you add a ``cities`` table to your database and define a foreign key that references an existing ``countries`` table. Then, you make a request to get the ``cities`` and their belonging ``countries``.
-
-.. tabs::
-
-  .. code-tab:: http
-
-    GET /cities?select=name,country:countries(id,name) HTTP/1.1
-
-  .. code-tab:: bash Curl
-
-    curl "http://localhost:3000/cities?select=name,country:countries(id,name)"
-
-The result will be an error:
-
-.. code-block:: json
-
-  {
-    "hint": "Verify that 'cities' and 'countries' exist in the schema 'api' and that there is a foreign key relationship between them. If a new relationship was created, try reloading the schema cache.",
-    "details": null,
-    "code": "PGRST200",
-    "message": "Could not find a relationship between 'cities' and 'countries' in the schema cache"
-  }
-
-As you can see, PostgREST couldn't find the newly created foreign key in the schema cache. See :ref:`schema_reloading` and :ref:`auto_schema_reloading` to solve this issue.
-
-.. _stale_function_signature:
-
-Stale Function Signature
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-The same issue will occur on newly created functions on a running PostgREST.
-
-.. code-block:: plpgsql
-
-  CREATE FUNCTION plus_one(num integer)
-  RETURNS integer AS $$
-   SELECT num + 1;
-  $$ LANGUAGE SQL IMMUTABLE;
-
-.. tabs::
-
-  .. code-tab:: http
-
-    GET /rpc/plus_one?num=1 HTTP/1.1
-
-  .. code-tab:: bash Curl
-
-    curl "http://localhost:3000/rpc/plus_one?num=1"
-
-.. code-block:: json
-
-  {
-    "hint": "If a new function was created in the database with this name and parameters, try reloading the schema cache.",
-    "details": null,
-    "code": "PGRST202",
-    "message": "Could not find the api.plus_one(num) function in the schema cache"
-  }
-
-Here, PostgREST tries to find the function on the stale schema to no avail. See :ref:`schema_reloading` and :ref:`auto_schema_reloading` to solve this issue.
+You can solve this by reloading the cache manually or automatically.
 
 .. _schema_reloading:
 
 Schema Cache Reloading
 ----------------------
 
-To reload the cache without restarting the PostgREST server, send a SIGUSR1 signal to the server process.
+To manually reload the cache without restarting the PostgREST server, send a SIGUSR1 signal to the server process.
 
 .. code:: bash
 
@@ -123,27 +57,29 @@ For docker you can do:
   # or in docker-compose
   docker-compose kill -s SIGUSR1 <service>
 
-There's no downtime when reloading the schema cache. The reloading will happen on a background thread while requests keep being served.
+There’s no downtime when reloading the schema cache. The reloading will happen on a background thread while serving requests.
 
 .. _schema_reloading_notify:
 
 Reloading with NOTIFY
 ~~~~~~~~~~~~~~~~~~~~~
 
-There are environments where you can't send the SIGUSR1 Unix Signal (like on managed containers in cloud services or on Windows systems). For this reason, PostgREST also allows you to reload its schema cache through PostgreSQL `NOTIFY <https://www.postgresql.org/docs/current/sql-notify.html>`_ as follows:
+PostgREST also allows you to reload its schema cache through PostgreSQL `NOTIFY <https://www.postgresql.org/docs/current/sql-notify.html>`_.
 
 .. code-block:: postgresql
 
   NOTIFY pgrst, 'reload schema'
 
-The ``"pgrst"`` notification channel is enabled by default. For configuring the channel, see :ref:`db-channel` and :ref:`db-channel-enabled`.
+This is useful in environments where you can’t send the SIGUSR1 Unix Signal. Like on cloud managed containers or on Windows systems.
+
+The ``pgrst`` notification channel is enabled by default. For configuring the channel, see :ref:`db-channel` and :ref:`db-channel-enabled`.
 
 .. _auto_schema_reloading:
 
 Automatic Schema Cache Reloading
 --------------------------------
 
-You can do automatic schema cache reloading in a pure SQL way and forget about stale schema cache errors with an `event trigger <https://www.postgresql.org/docs/current/event-trigger-definition.html>`_ and ``NOTIFY``.
+You can do automatic schema cache reloading in a pure SQL way and forget about stale schema cache errors. For this use an `event trigger <https://www.postgresql.org/docs/current/event-trigger-definition.html>`_ and ``NOTIFY``.
 
 .. code-block:: postgresql
 
@@ -161,9 +97,9 @@ You can do automatic schema cache reloading in a pure SQL way and forget about s
     ON ddl_command_end
     EXECUTE PROCEDURE pgrst_watch();
 
-Now, whenever the ``pgrst_watch`` trigger is fired in the database, PostgREST will automatically reload the schema cache.
+Now, whenever the ``pgrst_watch`` trigger fires, PostgREST will auto-reload the schema cache.
 
-To disable auto reloading, drop the trigger:
+To disable auto reloading, drop the trigger.
 
 .. code-block:: postgresql
 
@@ -172,12 +108,12 @@ To disable auto reloading, drop the trigger:
 Finer-Grained Event Trigger
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can refine the previous event trigger and only react to the events relevant to the schema cache. This also prevents unnecessary
-reloading when creating temporary tables(``CREATE TEMP TABLE``) inside functions.
+You can refine the previous event trigger to only react to the events relevant to the schema cache. This also prevents unnecessary
+reloading when creating temporary tables inside functions.
 
 .. code-block:: postgresql
 
-  -- watch create and alter
+  -- watch CREATE and ALTER
   CREATE OR REPLACE FUNCTION pgrst_ddl_watch() RETURNS event_trigger AS $$
   DECLARE
     cmd record;
@@ -204,7 +140,7 @@ reloading when creating temporary tables(``CREATE TEMP TABLE``) inside functions
     END LOOP;
   END; $$ LANGUAGE plpgsql;
 
-  -- watch drop
+  -- watch DROP
   CREATE OR REPLACE FUNCTION pgrst_drop_watch() RETURNS event_trigger AS $$
   DECLARE
     obj record;

--- a/docs/transactions.rst
+++ b/docs/transactions.rst
@@ -1,0 +1,320 @@
+.. raw:: html
+
+  <h1>Transactions</h1>
+
+Every :doc:`authenticated <auth>` request to an :doc:`API resource <api>` runs inside a transaction. The sequence of the transaction is as follows:
+
+.. code-block:: postgresql
+
+  BEGIN; -- <Access Mode> <Isolation Level>
+  -- <Transaction-scoped settings>
+  -- <Main Query>;
+  END;
+
+.. _access_mode:
+
+Access Mode
+===========
+
+The access mode on :ref:`tables_views` is determined by the HTTP method.
+
+.. list-table::
+   :header-rows: 1
+
+   * - HTTP Method
+     - Access Method
+   * - GET, HEAD
+     - READ ONLY
+   * - POST, PATCH, PUT, DELETE
+     - READ WRITE
+
+:ref:`s_procs` additionally depend on the function `volatility <https://www.postgresql.org/docs/current/xfunc-volatility.html>`_.
+
+.. list-table::
+   :header-rows: 2
+
+   * -
+     - Access Method
+     -
+     -
+   * - HTTP Method
+     - VOLATILE
+     - STABLE
+     - IMMUTABLE
+   * - GET, HEAD
+     - READ ONLY
+     - READ ONLY
+     - READ ONLY
+   * - POST
+     - READ WRITE
+     - READ ONLY
+     - READ ONLY
+
+Modifying the database inside READ ONLY transactions is not possible. PostgREST uses this fact to enforce HTTP semantics in GET and HEAD requests.
+
+.. note::
+
+  The volatility marker is a promise about the behavior of the function.  PostgreSQL will let you mark a function that modifies the database as ``IMMUTABLE`` or ``STABLE`` without failure.  But, because of the READ ONLY transaction the function will fail under PostgREST.
+
+The :ref:`options_requests` method doesn't start a transaction, so it's not relevant here.
+
+Isolation Level
+===============
+
+Every transaction uses the PostgreSQL default isolation level: READ COMMITTED.
+
+.. _tx_settings:
+
+Transaction-Scoped Settings
+===========================
+
+PostgREST uses settings tied to the transaction lifetime. These can be used to get data about the HTTP request. Or to modify the HTTP response.
+
+You can get these with ``current_setting``
+
+.. code-block:: postgresql
+
+  -- request settings use the ``request.`` prefix.
+  SELECT
+    current_setting('request.<setting>', true);
+
+And you can set them with ``set_config``
+
+.. code-block:: postgresql
+
+  -- response settings use the ``response.`` prefix.
+  SELECT
+    set_config('response.setting1', 'value1' ,true);
+
+Request Role and Search Path
+-----------------------------
+
+Because of :ref:`user_impersonation`, PostgREST sets the standard ``role``. You can get this in different ways:
+
+.. code-block:: postgresql
+
+  SELECT current_role;
+
+  SELECT current_user;
+
+  SELECT current_setting('role', true);
+
+Additionally it also sets the ``search_path`` based on :ref:`db-schemas` and :ref:`db-extra-search-path`.
+
+
+.. _guc_req_headers_cookies_claims:
+
+Request Headers, Cookies and JWT claims
+---------------------------------------
+
+PostgREST stores the headers, cookies and headers as JSON. To get them:
+
+.. code-block:: postgresql
+
+  -- To get all the headers sent in the request
+  SELECT current_setting('request.headers', true)::json;
+
+  -- To get a single header, you can use JSON arrow operators
+  SELECT current_setting('request.headers', true)::json->>'user-agent';
+
+  -- value of sessionId in a cookie
+  SELECT current_setting('request.cookies', true)::json->>'sessionId';
+
+  -- value of the email claim in a jwt
+  SELECT current_setting('request.jwt.claims', true)::json->>'email';
+
+.. note::
+
+  The ``role`` in ``request.jwt.claims`` defaults to the value of :ref:`db-anon-role`.
+
+.. _guc_req_path_method:
+
+Request Path and Method
+-----------------------
+
+The path and method are stored as ``text``.
+
+.. code-block:: postgresql
+
+  SELECT current_setting('request.path', true);
+
+  SELECT current_setting('request.method', true);
+
+.. _guc_resp_hdrs:
+
+Response Headers
+----------------
+
+You can set ``response.headers`` to add headers to the HTTP response. For instance, this statement would add caching headers to the response:
+
+.. code-block:: sql
+
+  -- tell client to cache response for two days
+
+  SELECT set_config('response.headers',
+    '[{"Cache-Control": "public"}, {"Cache-Control": "max-age=259200"}]', true);
+
+.. code-block:: http
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json; charset=utf-8
+  Cache-Control: no-cache, no-store, must-revalidate
+
+Notice that the ``response.headers`` should be set to an *array* of single-key objects rather than a single multiple-key object. This is because headers such as ``Cache-Control`` or ``Set-Cookie`` need repeating when setting many values. An object would not allow the repeated key.
+
+.. note::
+
+  PostgREST provided headers such as ``Content-Type``, ``Location``, etc. can be overriden this way. Note that irrespective of overridden ``Content-Type`` response header, the content will still be converted to JSON, unless you also set :ref:`raw-media-types` to something like ``text/html``.
+
+.. _guc_resp_status:
+
+Response Status Code
+--------------------
+
+You can set the ``response.status`` to override the default status code PostgREST provides. For instance, the following function would replace the default ``200`` status code.
+
+.. code-block:: postgres
+
+   create or replace function teapot() returns json as $$
+   begin
+     perform set_config('response.status', '418', true);
+     return json_build_object('message', 'The requested entity body is short and stout.',
+                              'hint', 'Tip it over and pour it out.');
+   end;
+   $$ language plpgsql;
+
+.. tabs::
+
+  .. code-tab:: http
+
+    GET /rpc/teapot HTTP/1.1
+
+  .. code-tab:: bash Curl
+
+    curl "http://localhost:3000/rpc/teapot" -i
+
+.. code-block:: http
+
+  HTTP/1.1 418 I'm a teapot
+
+  {
+    "message" : "The requested entity body is short and stout.",
+    "hint" : "Tip it over and pour it out."
+  }
+
+If the status code is standard, PostgREST will complete the status message(**I'm a teapot** in this example).
+
+Main query
+==========
+
+The main query is produced by requesting the :doc:`API resources <api>`.
+
+Transaction End
+===============
+
+If the transaction doesn't fail, it will always end in a COMMIT. Unless :ref:`db-tx-end` is configured to ROLLBACK in any case or conditionally with ``Prefer: tx=rollback``. This can be used for testing purposes.
+
+Aborting transactions
+=====================
+
+Any database failure(like a failed constraint) will result in a rollback of the transaction. You can also do a RAISE inside a function to cause a rollback.
+
+.. _raise_error:
+
+Raise errors with HTTP Status Codes
+-----------------------------------
+
+You can return non-200 HTTP status codes by raising SQL exceptions. For instance, here's a saucy function that always responds with an error:
+
+.. code-block:: postgresql
+
+  CREATE OR REPLACE FUNCTION just_fail() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+  BEGIN
+    RAISE EXCEPTION 'I refuse!'
+      USING DETAIL = 'Pretty simple',
+            HINT = 'There is nothing you can do.';
+  END
+  $$;
+
+Calling the function returns HTTP 400 with the body
+
+.. code-block:: json
+
+  {
+    "message":"I refuse!",
+    "details":"Pretty simple",
+    "hint":"There is nothing you can do.",
+    "code":"P0001"
+  }
+
+One way to customize the HTTP status code is by raising particular exceptions according to the PostgREST :ref:`error to status code mapping <status_codes>`. For example, :code:`RAISE insufficient_privilege` will respond with HTTP 401/403 as appropriate.
+
+For even greater control of the HTTP status code, raise an exception of the ``PTxyz`` type. For instance to respond with HTTP 402, raise 'PT402':
+
+.. code-block:: sql
+
+  RAISE sqlstate 'PT402' using
+    message = 'Payment Required',
+    detail = 'Quota exceeded',
+    hint = 'Upgrade your plan';
+
+Returns:
+
+.. code-block:: http
+
+  HTTP/1.1 402 Payment Required
+  Content-Type: application/json; charset=utf-8
+
+  {
+    "message": "Payment Required",
+    "details": "Quota exceeded",
+    "hint": "Upgrade your plan",
+    "code": "PT402"
+  }
+
+.. _pre-request:
+
+Pre-Request
+===========
+
+The pre-request is a function that can run after the :ref:`tx_settings` are set and before the main query. It's enabled with :ref:`db-pre-request`.
+
+This provides an opportunity to modify settings or raise an exception to prevent the request from completing.
+
+.. _pre_req_headers:
+
+Setting headers via pre-request
+-------------------------------
+
+As an example, let's add some cache headers for all requests that come from an Internet Explorer(6 or 7) browser.
+
+.. code-block:: postgresql
+
+   create or replace function custom_headers() returns void as $$
+   declare
+     user_agent text := current_setting('request.headers', true)::json->>'user-agent';
+   begin
+     if user_agent similar to '%MSIE (6.0|7.0)%' then
+       perform set_config('response.headers',
+         '[{"Cache-Control": "no-cache, no-store, must-revalidate"}]', false);
+     end if;
+   end; $$ language plpgsql;
+
+   -- set this function on postgrest.conf
+   -- db-pre-request = custom_headers
+
+Now when you make a GET request to a table or view, you'll get the cache headers.
+
+.. tabs::
+
+  .. code-tab:: http
+
+    GET /people HTTP/1.1
+    User-Agent: Mozilla/4.01 (compatible; MSIE 6.0; Windows NT 5.1)
+
+  .. code-tab:: bash Curl
+
+    curl "http://localhost:3000/people" -i \
+     -H "User-Agent: Mozilla/4.01 (compatible; MSIE 6.0; Windows NT 5.1)"

--- a/docs/transactions.rst
+++ b/docs/transactions.rst
@@ -2,7 +2,7 @@
 
   <h1>Transactions</h1>
 
-Every :doc:`authenticated <auth>` request to an :doc:`API resource <api>` runs inside a transaction. The sequence of the transaction is as follows:
+After :ref:`user_impersonation`, every request to an :doc:`API resource <api>` runs inside a transaction. The sequence of the transaction is as follows:
 
 .. code-block:: postgresql
 
@@ -84,7 +84,7 @@ And you can set them with ``set_config``
 
   -- response settings use the ``response.`` prefix.
   SELECT
-    set_config('response.setting1', 'value1' ,true);
+    set_config('response.<setting>', 'value1' ,true);
 
 Request Role and Search Path
 -----------------------------
@@ -204,6 +204,8 @@ You can set the ``response.status`` to override the default status code PostgRES
 
 If the status code is standard, PostgREST will complete the status message(**I'm a teapot** in this example).
 
+.. _main_query:
+
 Main query
 ==========
 
@@ -279,7 +281,7 @@ Returns:
 Pre-Request
 ===========
 
-The pre-request is a function that can run after the :ref:`tx_settings` are set and before the main query. It's enabled with :ref:`db-pre-request`.
+The pre-request is a function that can run after the :ref:`tx_settings` are set and before the :ref:`main_query`. It's enabled with :ref:`db-pre-request`.
 
 This provides an opportunity to modify settings or raise an exception to prevent the request from completing.
 
@@ -292,7 +294,8 @@ As an example, let's add some cache headers for all requests that come from an I
 
 .. code-block:: postgresql
 
-   create or replace function custom_headers() returns void as $$
+   create or replace function custom_headers()
+   returns void as $$
    declare
      user_agent text := current_setting('request.headers', true)::json->>'user-agent';
    begin

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx>=4.3.0
 sphinx-copybutton
 sphinx-rtd-theme>=0.5.1
 sphinx-tabs
+urllib3==2.0.2


### PR DESCRIPTION
Added a transactions reference which simplifies the API page and explains other undocumented functionality.

Clarified schema cache and errors page using https://hemingwayapp.com/.

- Closes https://github.com/PostgREST/postgrest-docs/issues/511.
- Closes https://github.com/PostgREST/postgrest-docs/issues/384