### PR TITLE
Fix in-db config settings

### DIFF
--- a/docs/explanations/install.rst
+++ b/docs/explanations/install.rst
@@ -32,7 +32,7 @@ You can also use your OS package manager.
 
       .. tab:: Arch Linux
 
-        You can install PostgREST from the `community repo <https://archlinux.org/packages/community/x86_64/postgrest>`_.
+        You can install PostgREST from the `community repo <https://archlinux.org/packages/extra/x86_64/postgrest/>`_.
 
         .. code:: bash
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -197,7 +197,6 @@ Here are some companies that use PostgREST in production.
 * `Drip Depot <https://www.dripdepot.com>`_
 * `Image-charts <https://www.image-charts.com>`_
 * `Moat <https://www.moat.com>`_
-* `MotionDynamic - Fast highly dynamic video generation at scale <https://motiondynamic.tech>`_
 * `Netwo <https://www.netwo.io>`_
 * `Nimbus <https://www.nimbusforwork.com>`_
   - See how Nimbus uses PostgREST in `Paul Copplestone's blog post <https://paul.copplest.one/blog/nimbus-tech-2019-04.html>`_.
@@ -206,8 +205,9 @@ Here are some companies that use PostgREST in production.
 * `Sompani <https://www.sompani.com>`_
 * `Supabase <https://supabase.com>`_
 
-.. Certs are failing
+.. Failing links
   * `eGull <http://www.egull.co>`_
+  * `MotionDynamic - Fast highly dynamic video generation at scale <https://motiondynamic.tech>`_
 
 Testimonials
 ------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,11 +82,6 @@ Leak-proof Abstraction
 
 There is no ORM involved. Creating new views happens in SQL with known performance implications. A database administrator can now create an API from scratch with no custom programming.
 
-Business Logic in Database Functions
-------------------------------------
-
-There is nothing "business" about keeping data segregated across piles of layers. Use database functions to process data and get the performance benefits of data colocality and reduced network roundtrips.
-
 One Thing Well
 --------------
 

--- a/docs/references/api/stored_procedures.rst
+++ b/docs/references/api/stored_procedures.rst
@@ -3,7 +3,7 @@
 Stored Procedures
 =================
 
-*"A single resource can be the equivalent of a database stored procedure, with the power to abstract state changes over any number of storage items"* -- `Roy T. Fielding <https://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven#comment-743>`_
+*"A single resource can be the equivalent of a database stored procedure, with the power to abstract state changes over any number of storage items"* -- `Roy T. Fielding <http://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven#comment-743>`_
 
 Every stored procedure in the :ref:`exposed schema <schemas>` and accessible by the :ref:`active database role <roles>` is executable under the :code:`/rpc` prefix. Procedures can perform any operations allowed by PostgreSQL (read data, modify data, and even DDL operations).
 

--- a/docs/references/auth.rst
+++ b/docs/references/auth.rst
@@ -42,7 +42,7 @@ This role switching mechanism is called **user impersonation**. In PostgreSQL it
 JWT-Based User Impersonation
 ----------------------------
 
-We use `JSON Web Tokens <https://jwt.io/>`_ to authenticate API requests. As you'll recall a JWT contains a list of cryptographically signed claims. All claims are allowed but PostgREST cares specifically about a claim called role.
+We use `JSON Web Tokens <https://jwt.io/>`_ to authenticate API requests, this allows us to be stateless and not require database lookups for verification. As you'll recall a JWT contains a list of cryptographically signed claims. All claims are allowed but PostgREST cares specifically about a claim called role.
 
 .. code:: json
 

--- a/docs/references/configuration.rst
+++ b/docs/references/configuration.rst
@@ -159,6 +159,7 @@ db-pool-acquisition-timeout Int     10
 db-pool-max-lifetime        Int     1800
 db-pre-request              String                    Y
 db-prepared-statements      Boolean True              Y
+db-root-spec                String                    Y
 db-schemas                  String  public            Y
 db-tx-end                   String  commit
 db-uri                      String  postgresql://
@@ -198,7 +199,7 @@ app.settings.*
 
   =============== ====================
   **Environment** PGRST_APP_SETTINGS_*
-  **In-Database** pgrst.app_settings_*
+  **In-Database** `n/a`
   =============== ====================
 
   Arbitrary settings that can be used to pass in secret keys directly as strings, or via OS environment variables. For instance: :code:`app.settings.jwt_secret = "$(MYAPP_JWT_SECRET)"` will take :code:`MYAPP_JWT_SECRET` from the environment and make it available to postgresql functions as :code:`current_setting('app.settings.jwt_secret')`.
@@ -210,7 +211,7 @@ db-anon-role
 
   =============== ==================
   **Environment** PGRST_DB_ANON_ROLE
-  **In-Database** `n/a`
+  **In-Database** `pgrst.db_anon_role`
   =============== ==================
 
   The database role to use when executing commands on behalf of unauthenticated clients. For more information, see :ref:`roles`.

--- a/postgrest.dict
+++ b/postgrest.dict
@@ -83,6 +83,7 @@ Kofi
 Kubernetes
 localhost
 login
+lookups
 Logins
 logins
 lon


### PR DESCRIPTION
- `app.settings` never worked with in-db. Correct this. (making it work seems unnecessary since it was meant to be used with env vars).
- `db-root-spec` added to the global table.