### PR TITLE
jwt-secret-is-base64 = False fails initialization, expects false

### DIFF
--- a/docs/references/configuration.rst
+++ b/docs/references/configuration.rst
@@ -45,7 +45,7 @@ The configuration file must contain a set of key value pairs:
   # The secret to verify the JWT for authenticated requests with.
   # Needs to be 32 characters minimum.
   jwt-secret           = "reallyreallyreallyreallyverysafe"
-  jwt-secret-is-base64 = False
+  jwt-secret-is-base64 = false
 
   # Port the postgrest process is listening on for http requests
   server-port = 80


### PR DESCRIPTION
postgrest: FatalError {fatalErrorMessage = "Error in config ParseError \"postgrest.conf:14:22:\\n   |\\n14 | jwt-secret-is-base64=False\\n   |                      ^^^^^\\nunexpected \\\"False\\\"\\nexpecting \\\"false\\\", \\\"off\\\", \\\"on\\\", \\\"true\\\", '\\\"', '[', or digit\\n\""}