### PR TITLE
Note content-type for singular objects

### DIFF
--- a/docs/references/api/resource_representation.rst
+++ b/docs/references/api/resource_representation.rst
@@ -66,7 +66,7 @@ This returns
 
   { "id": 1 }
 
-with a :code:`Content-Type` that begins :code:`application/vnd.pgrst.object+json`.
+with a :code:`Content-Type: application/vnd.pgrst.object+json`.
 
 When a singular response is requested but no entries are found, the server responds with an error message and 406 Not Acceptable status code rather than the usual empty array and 200 status:
 

--- a/docs/references/api/resource_representation.rst
+++ b/docs/references/api/resource_representation.rst
@@ -66,6 +66,8 @@ This returns
 
   { "id": 1 }
 
+with a :code:`Content-Type` that begins :code:`application/vnd.pgrst.object+json`.
+
 When a singular response is requested but no entries are found, the server responds with an error message and 406 Not Acceptable status code rather than the usual empty array and 200 status:
 
 .. code-block:: json


### PR DESCRIPTION
Resolves PostgREST/postgrest#2809

I hit this issue when replacing the backend for a client that was naively testing the `Content-Type` was `application/json`. This small change would have saved me significant debugging. Hopefully it will help others, too.
