### PR TITLE
Change example getallfilms to stable instead of immutable

### DIFF
--- a/docs/references/api/resource_embedding.rst
+++ b/docs/references/api/resource_embedding.rst
@@ -742,7 +742,7 @@ Here's a sample function (notice the ``RETURNS SETOF films``).
 
   CREATE FUNCTION getallfilms() RETURNS SETOF films AS $$
     SELECT * FROM films;
-  $$ LANGUAGE SQL IMMUTABLE;
+  $$ LANGUAGE SQL STABLE;
 
 A request with ``directors`` embedded:
 


### PR DESCRIPTION
Hi, while reading the docs I noticed that example function `getallfilms` was marked as immutable. However, wouldn't stable be a more correct volatility marker given the fact that it queries the database and returns value of a database select?