### PR TITLE
dev: add postgrest-docs-check

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,7 +20,7 @@ let
 
   python = pkgs.python3.withPackages (ps: [ ps.sphinx ps.sphinx_rtd_theme ps.livereload (sphinxTabsPkg ps) (sphinxCopybuttonPkg ps) ]);
 in
-{
+rec {
   inherit pkgs;
 
   build =
@@ -84,5 +84,16 @@ in
         set -euo pipefail
 
         ${python}/bin/sphinx-build --color -b linkcheck docs _build
+      '';
+
+  check =
+    pkgs.writeShellScriptBin "postgrest-docs-check"
+      ''
+        set -euo pipefail
+        ${build}/bin/postgrest-docs-build
+        ${dictcheck}/bin/postgrest-docs-dictcheck
+        ${linkcheck}/bin/postgrest-docs-linkcheck
+        ${spellcheck}/bin/postgrest-docs-spellcheck
+
       '';
 }

--- a/default.nix
+++ b/default.nix
@@ -94,6 +94,5 @@ rec {
         ${dictcheck}/bin/postgrest-docs-dictcheck
         ${linkcheck}/bin/postgrest-docs-linkcheck
         ${spellcheck}/bin/postgrest-docs-spellcheck
-
       '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,7 @@ pkgs.mkShell {
     docs.spellcheck
     docs.dictcheck
     docs.linkcheck
+    docs.check
   ];
 
   shellHook = ''


### PR DESCRIPTION
I have wrapped the commands: `build`, `linkcheck`, `dictcheck` and `spellcheck` into a single command `postgrest-docs-check`. It is easier to use this command to check everything before pushing.
