### PR TITLE
server-port can be 0

### DIFF
--- a/docs/references/configuration.rst
+++ b/docs/references/configuration.rst
@@ -825,7 +825,7 @@ server-port
   **In-Database** `n/a`
   =============== =================================
 
-  The TCP port to bind the web server.
+  The TCP port to bind the web server. Use ``0`` to automatically assign a port.
 
 .. _server-trace-header:
 


### PR DESCRIPTION
Introduces special value of `0` for port to be assigned randomly

Depends on https://github.com/PostgREST/postgrest/pull/3034