### PR TITLE
add documentation for statement_timeout set on functions

### DIFF
--- a/docs/references/auth.rst
+++ b/docs/references/auth.rst
@@ -39,6 +39,10 @@ The picture below shows how the server handles authentication. If auth succeeds,
 
 This role switching mechanism is called **user impersonation**. In PostgreSQL it's done with the ``SET ROLE`` statement.
 
+.. note::
+
+  The impersonated roles will have their settings applied. See :ref:`impersonated_settings`.
+
 .. _jwt_impersonation:
 
 JWT-Based User Impersonation

--- a/docs/references/auth.rst
+++ b/docs/references/auth.rst
@@ -39,24 +39,6 @@ The picture below shows how the server handles authentication. If auth succeeds,
 
 This role switching mechanism is called **user impersonation**. In PostgreSQL it's done with the ``SET ROLE`` statement.
 
-.. _impersonated_settings:
-
-Impersonated Role Settings
---------------------------
-
-The impersonated role has its settings applied. For example, if you do:
-
-.. code-block:: postgresql
-
-  ALTER ROLE webuser SET statement_timeout TO '5s';
-
-Every ``webuser`` :ref:`transaction <transactions>` gets its queries executed with a ``statement_timeout`` of 5 seconds.
-
-.. note::
-
-   Settings that have a high privilege context (like ``superuser``) won't be applied, only settings that have a ``user`` context will be. This is so we don't cause permission errors.
-   For more details see `Understanding Postgres Parameter Context <https://www.enterprisedb.com/blog/understanding-postgres-parameter-context>`_.
-
 .. _jwt_impersonation:
 
 JWT-Based User Impersonation


### PR DESCRIPTION
Add documentation for statement timeout set on functions. Also move `impersonated role settings` from `auth.rst` to `transactions.rst`.