### PR TITLE
Fix secret command to avoid non-ascii alphanumerics

### DIFF
--- a/docs/tutorials/tut1.rst
+++ b/docs/tutorials/tut1.rst
@@ -41,7 +41,7 @@ Let's create a password and provide it to PostgREST. Think of a nice long one, o
     export LC_CTYPE=C
 
     # read random bytes and keep only alphanumerics
-    echo "jwt-secret = \"$(< /dev/urandom tr -dc A-Za-z0-9 | head -c32)\"" >> tutorial.conf
+    echo "jwt-secret = \"$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c32)\"" >> tutorial.conf
 
 
 check the :code:`tutorial.conf` (created in the previous tutorial) the line with the password:


### PR DESCRIPTION
Example of result with the older command:
`��l6N�z���ݹ�raDp��yQMd1���Zah�`